### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/tylerbutler/repoverlay/compare/v0.1.2...v0.1.3) - 2026-01-07
+
+### Other
+
+- use PAT for release-plz to trigger release workflow
+
 ## [0.1.2](https://github.com/tylerbutler/repoverlay/compare/v0.1.1...v0.1.2) - 2026-01-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repoverlay"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoverlay"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Overlay config files into git repositories without committing them"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `repoverlay`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/tylerbutler/repoverlay/compare/v0.1.2...v0.1.3) - 2026-01-07

### Other

- use PAT for release-plz to trigger release workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).