### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/tylerbutler/repoverlay/compare/v0.1.3...v0.1.4) - 2026-01-15
+
+### Added
+
+- add overlay repository management with CCL config format
+- add interactive mode for overlay creation
+- add smart discovery for overlay creation
+- add create and switch commands
+
+### Fixed
+
+- coverage workflow builds binary before running tests
+- resolve clippy warnings and coverage workflow issues
+
+### Other
+
+- improve test coverage for cache, config, github, and overlay_repo modules
+- add code coverage, security audit, and documentation checks
+- extract helper functions to reduce code duplication
+
 ## [0.1.3](https://github.com/tylerbutler/repoverlay/compare/v0.1.2...v0.1.3) - 2026-01-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repoverlay"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoverlay"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Overlay config files into git repositories without committing them"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `repoverlay`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/tylerbutler/repoverlay/compare/v0.1.3...v0.1.4) - 2026-01-15

### Added

- add overlay repository management with CCL config format
- add interactive mode for overlay creation
- add smart discovery for overlay creation
- add create and switch commands

### Fixed

- coverage workflow builds binary before running tests
- resolve clippy warnings and coverage workflow issues

### Other

- improve test coverage for cache, config, github, and overlay_repo modules
- add code coverage, security audit, and documentation checks
- extract helper functions to reduce code duplication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).