### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/tylerbutler/repoverlay/compare/v0.1.4...v0.1.5) - 2026-01-21
+
+### Other
+
+- simplify state format using sickle's improved serde support ([#11](https://github.com/tylerbutler/repoverlay/pull/11))
+- improve documentation structure and clarity ([#10](https://github.com/tylerbutler/repoverlay/pull/10))
+- document decision to use git CLI over git library
+- extract library crate and reorganize tests ([#8](https://github.com/tylerbutler/repoverlay/pull/8))
+
 ## [0.1.4](https://github.com/tylerbutler/repoverlay/compare/v0.1.3...v0.1.4) - 2026-01-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repoverlay"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoverlay"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Overlay config files into git repositories without committing them"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `repoverlay`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/tylerbutler/repoverlay/compare/v0.1.4...v0.1.5) - 2026-01-21

### Other

- simplify state format using sickle's improved serde support ([#11](https://github.com/tylerbutler/repoverlay/pull/11))
- improve documentation structure and clarity ([#10](https://github.com/tylerbutler/repoverlay/pull/10))
- document decision to use git CLI over git library
- extract library crate and reorganize tests ([#8](https://github.com/tylerbutler/repoverlay/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).