### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/tylerbutler/repoverlay/compare/v0.1.5...v0.1.6) - 2026-01-22
+
+### Added
+
+- simplify overlay publishing workflow ([#16](https://github.com/tylerbutler/repoverlay/pull/16))
+- *(create)* add interactive file selection UI with category filters ([#17](https://github.com/tylerbutler/repoverlay/pull/17))
+- use ~/.config for config and default create to overlay repo ([#12](https://github.com/tylerbutler/repoverlay/pull/12))
+
+### Fixed
+
+- improve terminal interactivity detection
+- use output_dir for create command default path ([#15](https://github.com/tylerbutler/repoverlay/pull/15))
+
+### Other
+
+- improve code coverage for overlay_repo and selection modules ([#21](https://github.com/tylerbutler/repoverlay/pull/21))
+- improve code coverage for cache, lib, and main modules ([#20](https://github.com/tylerbutler/repoverlay/pull/20))
+- *(deps)* upgrade dependencies ([#19](https://github.com/tylerbutler/repoverlay/pull/19))
+
 ## [0.1.5](https://github.com/tylerbutler/repoverlay/compare/v0.1.4...v0.1.5) - 2026-01-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repoverlay"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoverlay"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Overlay config files into git repositories without committing them"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `repoverlay`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/tylerbutler/repoverlay/compare/v0.1.5...v0.1.6) - 2026-01-22

### Added

- simplify overlay publishing workflow ([#16](https://github.com/tylerbutler/repoverlay/pull/16))
- *(create)* add interactive file selection UI with category filters ([#17](https://github.com/tylerbutler/repoverlay/pull/17))
- use ~/.config for config and default create to overlay repo ([#12](https://github.com/tylerbutler/repoverlay/pull/12))

### Fixed

- improve terminal interactivity detection
- use output_dir for create command default path ([#15](https://github.com/tylerbutler/repoverlay/pull/15))

### Other

- improve code coverage for overlay_repo and selection modules ([#21](https://github.com/tylerbutler/repoverlay/pull/21))
- improve code coverage for cache, lib, and main modules ([#20](https://github.com/tylerbutler/repoverlay/pull/20))
- *(deps)* upgrade dependencies ([#19](https://github.com/tylerbutler/repoverlay/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).