### PR TITLE
test: improve code coverage for cache, lib, and main modules

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -983,7 +983,9 @@ mod tests {
             .unwrap();
 
         // This branch doesn't exist
-        let result = manager.ref_exists(&repo_path, "origin/nonexistent-branch").unwrap();
+        let result = manager
+            .ref_exists(&repo_path, "origin/nonexistent-branch")
+            .unwrap();
         assert!(!result);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1574,15 +1574,13 @@ mod tests {
 
         #[test]
         fn returns_false_for_only_managed_section() {
-            let content =
-                "# repoverlay:managed start\n.repoverlay\n# repoverlay:managed end\n";
+            let content = "# repoverlay:managed start\n.repoverlay\n# repoverlay:managed end\n";
             assert!(!any_overlay_sections_remain(content));
         }
 
         #[test]
         fn returns_true_for_overlay_section() {
-            let content =
-                "# repoverlay:my-overlay start\n.envrc\n# repoverlay:my-overlay end\n";
+            let content = "# repoverlay:my-overlay start\n.envrc\n# repoverlay:my-overlay end\n";
             assert!(any_overlay_sections_remain(content));
         }
 
@@ -1706,7 +1704,12 @@ mod tests {
             let dir = TempDir::new().unwrap();
             let result = validate_git_repo(dir.path());
             assert!(result.is_err());
-            assert!(result.unwrap_err().to_string().contains("not a git repository"));
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("not a git repository")
+            );
         }
     }
 
@@ -1740,12 +1743,9 @@ mod tests {
 
             fs::write(source.path().join("file.txt"), "content").unwrap();
 
-            let copied = copy_files_to_overlay(
-                source.path(),
-                output.path(),
-                &[PathBuf::from("file.txt")],
-            )
-            .unwrap();
+            let copied =
+                copy_files_to_overlay(source.path(), output.path(), &[PathBuf::from("file.txt")])
+                    .unwrap();
 
             assert_eq!(copied.len(), 1);
             assert!(output.path().join("file.txt").exists());
@@ -1760,12 +1760,9 @@ mod tests {
             fs::write(source.path().join("dir/file1.txt"), "content1").unwrap();
             fs::write(source.path().join("dir/subdir/file2.txt"), "content2").unwrap();
 
-            let copied = copy_files_to_overlay(
-                source.path(),
-                output.path(),
-                &[PathBuf::from("dir")],
-            )
-            .unwrap();
+            let copied =
+                copy_files_to_overlay(source.path(), output.path(), &[PathBuf::from("dir")])
+                    .unwrap();
 
             assert_eq!(copied.len(), 2);
             assert!(output.path().join("dir/file1.txt").exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2474,7 +2474,12 @@ mod tests {
 
             // Add a GitHub remote
             Command::new("git")
-                .args(["remote", "add", "origin", "https://github.com/testorg/testrepo.git"])
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/testorg/testrepo.git",
+                ])
                 .current_dir(source.path())
                 .output()
                 .unwrap();
@@ -2505,7 +2510,12 @@ mod tests {
             let repo = create_test_repo();
 
             Command::new("git")
-                .args(["remote", "add", "origin", "https://github.com/owner/repo.git"])
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/owner/repo.git",
+                ])
                 .current_dir(repo.path())
                 .output()
                 .unwrap();
@@ -2539,7 +2549,12 @@ mod tests {
             let repo = create_test_repo();
 
             Command::new("git")
-                .args(["remote", "add", "origin", "https://gitlab.com/owner/repo.git"])
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://gitlab.com/owner/repo.git",
+                ])
                 .current_dir(repo.path())
                 .output()
                 .unwrap();
@@ -2561,7 +2576,12 @@ mod tests {
                 repo: "invalid".to_string(),
             });
             assert!(result.is_err());
-            assert!(result.unwrap_err().to_string().contains("Invalid repository format"));
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Invalid repository format")
+            );
         }
 
         #[test]
@@ -2570,7 +2590,12 @@ mod tests {
                 repo: "a/b/c".to_string(),
             });
             assert!(result.is_err());
-            assert!(result.unwrap_err().to_string().contains("Invalid repository format"));
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Invalid repository format")
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Add 63 new unit tests covering previously untested code paths
- Improve coverage for `cache.rs`: `check_for_updates()`, metadata handling, git ref operations
- Improve coverage for `lib.rs`: GitHub URL parsing, git exclude management, path utilities
- Improve coverage for `main.rs`: overlay name parsing, target repo detection, cache command validation

Total tests increased from 222 to 285.