### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/tylerbutler/repoverlay/compare/v0.1.6...v0.2.0) - 2026-01-26
+
+### Added
+
+- add fork inheritance for overlay resolution ([#24](https://github.com/tylerbutler/repoverlay/pull/24))
+- add hk git hooks for lint and format ([#25](https://github.com/tylerbutler/repoverlay/pull/25))
+
+### Other
+
+- remove public library API ([#27](https://github.com/tylerbutler/repoverlay/pull/27))
+- add license
+- add Claude Code configuration and skills ([#22](https://github.com/tylerbutler/repoverlay/pull/22))
+
 ## [0.1.6](https://github.com/tylerbutler/repoverlay/compare/v0.1.5...v0.1.6) - 2026-01-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "repoverlay"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoverlay"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2024"
 description = "Overlay config files into git repositories without committing them"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `repoverlay`: 0.1.6 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `repoverlay` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum repoverlay::github::GitRef, previously in file /tmp/.tmpXdhF06/repoverlay/src/github.rs:21
  enum repoverlay::state::OverlaySource, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:26
  enum repoverlay::OverlaySource, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:26
  enum repoverlay::state::LinkType, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:211
  enum repoverlay::LinkType, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:211
  enum repoverlay::detection::FileCategory, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:11

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function repoverlay::detection::group_by_category, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:186
  function repoverlay::state::load_external_states, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:297
  function repoverlay::load_external_states, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:297
  function repoverlay::detection::detect_untracked_files, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:134
  function repoverlay::state::save_external_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:255
  function repoverlay::save_external_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:255
  function repoverlay::detection::detect_ai_configs, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:85
  function repoverlay::selection::humanize_count, previously in file /tmp/.tmpXdhF06/repoverlay/src/selection.rs:21
  function repoverlay::config::generate_config_ccl, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:106
  function repoverlay::state::external_state_dir, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:238
  function repoverlay::parse_github_owner_repo, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1451
  function repoverlay::config::load_repo_config, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:73
  function repoverlay::remove_overlay_section, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1406
  function repoverlay::config::repo_config_path, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:53
  function repoverlay::switch_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1320
  function repoverlay::config::config_dir, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:35
  function repoverlay::print_overlay_created, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1265
  function repoverlay::copy_files_to_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1206
  function repoverlay::state::save_overlay_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:426
  function repoverlay::save_overlay_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:426
  function repoverlay::canonicalize_path, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:32
  function repoverlay::restore_overlays, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:653
  function repoverlay::state::list_applied_overlays, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:386
  function repoverlay::list_applied_overlays, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:386
  function repoverlay::selection::select_files, previously in file /tmp/.tmpXdhF06/repoverlay/src/selection.rs:285
  function repoverlay::show_status, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:524
  function repoverlay::state::normalize_overlay_name, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:341
  function repoverlay::normalize_overlay_name, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:341
  function repoverlay::remove_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:400
  function repoverlay::state::exclude_marker_start, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:331
  function repoverlay::exclude_marker_start, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:331
  function repoverlay::resolve_source, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:67
  function repoverlay::detection::discover_files, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:164
  function repoverlay::cache::cache_dir, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:402
  function repoverlay::state::remove_external_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:273
  function repoverlay::remove_external_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:273
  function repoverlay::detection::detect_gitignored_files, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:106
  function repoverlay::config::save_global_config_with_comments, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:132
  function repoverlay::state::external_state_dir_for_target, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:248
  function repoverlay::detection::is_ai_config, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:60
  function repoverlay::overlay_repo::parse_overlay_reference, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:358
  function repoverlay::config::load_config, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:92
  function repoverlay::any_overlay_sections_remain, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1437
  function repoverlay::overlay_repo::default_overlay_repo_path, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:327
  function repoverlay::config::load_global_config, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:58
  function repoverlay::update_git_exclude, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1347
  function repoverlay::config::global_config_path, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:48
  function repoverlay::create_overlay_with_files, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1286
  function repoverlay::generate_overlay_config, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:1244
  function repoverlay::create_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:931
  function repoverlay::validate_git_repo, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:38
  function repoverlay::update_overlays, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:756
  function repoverlay::state::load_overlay_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:413
  function repoverlay::load_overlay_state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:413
  function repoverlay::show_single_overlay_status, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:573
  function repoverlay::state::load_all_overlay_targets, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:356
  function repoverlay::load_all_overlay_targets, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:356
  function repoverlay::remove_single_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:442
  function repoverlay::state::exclude_marker_end, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:336
  function repoverlay::exclude_marker_end, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:336
  function repoverlay::apply_overlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:192

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod repoverlay::config, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:1
  mod repoverlay::detection, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:1
  mod repoverlay::selection, previously in file /tmp/.tmpXdhF06/repoverlay/src/selection.rs:1
  mod repoverlay::overlay_repo, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:1
  mod repoverlay::github, previously in file /tmp/.tmpXdhF06/repoverlay/src/github.rs:1
  mod repoverlay::cache, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:1
  mod repoverlay::state, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  MANAGED_SECTION_NAME in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:21
  MANAGED_SECTION_NAME in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:21
  AI_CONFIG_PATTERNS in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:34
  CONFIG_FILE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:19
  CONFIG_FILE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:19
  OVERLAYS_DIR in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:17
  OVERLAYS_DIR in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:17
  GIT_EXCLUDE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:20
  GIT_EXCLUDE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:20
  META_FILE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:18
  META_FILE in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:18
  STATE_DIR in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:16
  STATE_DIR in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:16

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct repoverlay::state::FileEntry, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:202
  struct repoverlay::FileEntry, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:202
  struct repoverlay::detection::DetectedFile, previously in file /tmp/.tmpXdhF06/repoverlay/src/detection.rs:22
  struct repoverlay::cache::CachedRepoInfo, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:66
  struct repoverlay::selection::SelectionConfig, previously in file /tmp/.tmpXdhF06/repoverlay/src/selection.rs:40
  struct repoverlay::cache::CacheMeta, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:41
  struct repoverlay::overlay_repo::OverlayRepoMeta, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:24
  struct repoverlay::ResolvedSource, previously in file /tmp/.tmpXdhF06/repoverlay/src/lib.rs:46
  struct repoverlay::state::OverlayState, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:165
  struct repoverlay::OverlayState, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:165
  struct repoverlay::config::OverlayRepoConfig, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:22
  struct repoverlay::cache::CachedOverlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:54
  struct repoverlay::selection::SelectionResult, previously in file /tmp/.tmpXdhF06/repoverlay/src/selection.rs:32
  struct repoverlay::state::GlobalMeta, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:153
  struct repoverlay::GlobalMeta, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:153
  struct repoverlay::state::OverlayConfig, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:220
  struct repoverlay::OverlayConfig, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:220
  struct repoverlay::state::OverlayConfigMeta, previously in file /tmp/.tmpXdhF06/repoverlay/src/state.rs:229
  struct repoverlay::github::GitHubSource, previously in file /tmp/.tmpXdhF06/repoverlay/src/github.rs:12
  struct repoverlay::GitHubSource, previously in file /tmp/.tmpXdhF06/repoverlay/src/github.rs:12
  struct repoverlay::cache::CacheManager, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:78
  struct repoverlay::CacheManager, previously in file /tmp/.tmpXdhF06/repoverlay/src/cache.rs:78
  struct repoverlay::overlay_repo::AvailableOverlay, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:35
  struct repoverlay::overlay_repo::OverlayRepoManager, previously in file /tmp/.tmpXdhF06/repoverlay/src/overlay_repo.rs:47
  struct repoverlay::config::RepoverlayConfig, previously in file /tmp/.tmpXdhF06/repoverlay/src/config.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/tylerbutler/repoverlay/compare/v0.1.6...v0.2.0) - 2026-01-26

### Added

- add fork inheritance for overlay resolution ([#24](https://github.com/tylerbutler/repoverlay/pull/24))
- add hk git hooks for lint and format ([#25](https://github.com/tylerbutler/repoverlay/pull/25))

### Other

- remove public library API ([#27](https://github.com/tylerbutler/repoverlay/pull/27))
- add license
- add Claude Code configuration and skills ([#22](https://github.com/tylerbutler/repoverlay/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).