### PR TITLE
feat: add hk git hooks for lint and format

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,37 @@
+amends "package://github.com/jdx/hk/releases/download/v1.28.0/hk@1.28.0#/Config.pkl"
+
+local cargo_fmt = new Step {
+    glob = List("*.rs")
+    check = "cargo fmt -- --check"
+    fix = "cargo fmt"
+}
+
+local cargo_clippy = new Step {
+    glob = List("*.rs")
+    check = "cargo clippy --all-targets --all-features -- -D warnings"
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stage = true
+        steps {
+            ["cargo-fmt"] = cargo_fmt
+            ["cargo-clippy"] = cargo_clippy
+        }
+    }
+    ["fix"] {
+        fix = true
+        steps {
+            ["cargo-fmt"] = cargo_fmt
+            ["cargo-clippy"] = cargo_clippy
+        }
+    }
+    ["check"] {
+        fix = false
+        steps {
+            ["cargo-fmt"] = cargo_fmt
+            ["cargo-clippy"] = cargo_clippy
+        }
+    }
+}


### PR DESCRIPTION
Add hk configuration for automated code quality checks on commit.

- Configure `cargo fmt` and `cargo clippy` to run on `.rs` files
- Pre-commit hook auto-fixes formatting and re-stages files
- Add `fix` hook for on-demand linting
- Add `check` hook for CI validation