### PR TITLE
feat(cli): add subcommand to add files to existing overlays

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3381,5 +3381,73 @@ mod tests {
                 _ => panic!("Expected Add command"),
             }
         }
+
+        #[test]
+        fn add_accepts_multiple_files() {
+            let cli = Cli::try_parse_from([
+                "repoverlay",
+                "add",
+                "my-overlay",
+                "file1.txt",
+                "file2.txt",
+                "dir/file3.txt",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Commands::Add { files, .. } => {
+                    assert_eq!(files.len(), 3);
+                    assert_eq!(files[0], PathBuf::from("file1.txt"));
+                    assert_eq!(files[1], PathBuf::from("file2.txt"));
+                    assert_eq!(files[2], PathBuf::from("dir/file3.txt"));
+                }
+                _ => panic!("Expected Add command"),
+            }
+        }
+
+        #[test]
+        fn add_accepts_files_with_special_characters() {
+            let cli = Cli::try_parse_from([
+                "repoverlay",
+                "add",
+                "my-overlay",
+                "file with spaces.txt",
+                ".hidden-file",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Commands::Add { files, .. } => {
+                    assert_eq!(files.len(), 2);
+                    assert_eq!(files[0], PathBuf::from("file with spaces.txt"));
+                    assert_eq!(files[1], PathBuf::from(".hidden-file"));
+                }
+                _ => panic!("Expected Add command"),
+            }
+        }
+
+        #[test]
+        fn add_dry_run_defaults_to_false() {
+            let cli = Cli::try_parse_from(["repoverlay", "add", "my-overlay", "file.txt"]).unwrap();
+
+            match cli.command {
+                Commands::Add { dry_run, .. } => {
+                    assert!(!dry_run);
+                }
+                _ => panic!("Expected Add command"),
+            }
+        }
+
+        #[test]
+        fn add_target_defaults_to_none() {
+            let cli = Cli::try_parse_from(["repoverlay", "add", "my-overlay", "file.txt"]).unwrap();
+
+            match cli.command {
+                Commands::Add { target, .. } => {
+                    assert!(target.is_none());
+                }
+                _ => panic!("Expected Add command"),
+            }
+        }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -899,3 +899,89 @@ fn add_fails_when_no_files_specified() {
         .failure()
         .stderr(predicate::str::contains("No files specified"));
 }
+
+#[test]
+fn add_fails_when_target_not_git_repo() {
+    let non_git_dir = tempfile::TempDir::new().unwrap();
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["add", "org/repo/my-overlay", "file.txt"])
+        .args(["--target", non_git_dir.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not a git repository"));
+}
+
+#[test]
+fn add_fails_when_file_does_not_exist() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay first
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", ctx.overlay_source()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "test-overlay"])
+        .assert()
+        .success();
+
+    // Try to add a file that doesn't exist
+    cargo_bin_cmd!("repoverlay")
+        .args(["add", "org/repo/test-overlay", "nonexistent-file.txt"])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("File does not exist"));
+}
+
+#[test]
+fn add_dry_run_shows_files_without_changes() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay first
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", ctx.overlay_source()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "test-overlay"])
+        .assert()
+        .success();
+
+    // Create a file to add
+    ctx.create_repo_file("newfile.txt", "new content");
+
+    // Run add with --dry-run
+    cargo_bin_cmd!("repoverlay")
+        .args(["add", "org/repo/test-overlay", "newfile.txt", "--dry-run"])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dry run"))
+        .stdout(predicate::str::contains("newfile.txt"));
+
+    // File should still exist as regular file, not symlink
+    assert!(ctx.file_exists("newfile.txt"));
+    assert!(
+        !ctx.is_symlink("newfile.txt"),
+        "File should not be converted to symlink in dry-run mode"
+    );
+}
+
+#[test]
+fn add_fails_when_file_already_in_overlay() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", ctx.overlay_source()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "test-overlay"])
+        .assert()
+        .success();
+
+    // Try to add a file that's already managed by the overlay
+    cargo_bin_cmd!("repoverlay")
+        .args(["add", "org/repo/test-overlay", ".envrc"])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already managed"));
+}


### PR DESCRIPTION
## Summary

Adds a new `add` subcommand that allows adding files to an existing applied overlay, addressing the workflow gap where users had to recreate overlays or manually edit them.

## Changes

- New `repoverlay add <overlay-name> <file>...` command
- Copies files to overlay repo, replaces originals with symlinks
- Updates overlay state, git exclude, and external backup
- Auto-commits and pushes to overlay repo
- Supports `--dry-run` and `--target` options
- Includes CLI parsing tests and integration tests

Closes #28