### PR TITLE
build: add conventional commit enforcement tooling

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,46 @@
+{
+  "extends": [
+    "@commitlint/config-conventional"
+  ],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "improvement",
+        "docs",
+        "perf",
+        "style",
+        "refactor",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [
+      2,
+      "never",
+      [
+        "upper-case"
+      ]
+    ],
+    "subject-empty": [
+      2,
+      "never"
+    ],
+    "subject-full-stop": [
+      2,
+      "never",
+      "."
+    ],
+    "header-max-length": [
+      2,
+      "always",
+      100
+    ]
+  }
+}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,37 @@
+# git-cliff config for repoverlay
+# Auto-generated from commit-types.json - edit that file instead
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [unreleased]
+{% endif %}\
+{% for group, group_commits in commits | group_by(attribute="group") %}\
+{% if group != "_ignored" %}
+### {{ group | upper_first }}
+{% for commit in group_commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endif %}\
+{% endfor %}\
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+tag_pattern = "v[0-9].*"
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^improvement", group = "Improvements" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = ".*", group = "_ignored" },
+]

--- a/commit-types.json
+++ b/commit-types.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Single source of truth for conventional commit types used by commitlint and git-cliff",
+  "types": {
+    "feat": {
+      "description": "A new feature",
+      "changelog_group": "Features"
+    },
+    "fix": {
+      "description": "A bug fix",
+      "changelog_group": "Bug Fixes"
+    },
+    "improvement": {
+      "description": "An improvement to an existing feature",
+      "changelog_group": "Improvements"
+    },
+    "docs": {
+      "description": "Documentation only changes",
+      "changelog_group": "Documentation"
+    },
+    "perf": {
+      "description": "A code change that improves performance",
+      "changelog_group": "Performance"
+    },
+    "style": {
+      "description": "Changes that do not affect the meaning of the code",
+      "changelog_group": null
+    },
+    "refactor": {
+      "description": "A code change that neither fixes a bug nor adds a feature",
+      "changelog_group": null
+    },
+    "test": {
+      "description": "Adding missing tests or correcting existing tests",
+      "changelog_group": null
+    },
+    "build": {
+      "description": "Changes that affect the build system or external dependencies",
+      "changelog_group": null
+    },
+    "ci": {
+      "description": "Changes to CI configuration files and scripts",
+      "changelog_group": null
+    },
+    "chore": {
+      "description": "Other changes that don't modify src or test files",
+      "changelog_group": null
+    },
+    "revert": {
+      "description": "Reverts a previous commit",
+      "changelog_group": null
+    }
+  },
+  "commitlint_rules": {
+    "subject-case": [2, "never", ["upper-case"]],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 100]
+  }
+}

--- a/scripts/check-configs-sync.py
+++ b/scripts/check-configs-sync.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Verify that generated configs match commit-types.json (single source of truth)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_generated_content(script: str) -> str:
+    """Run a generator script with --dry-run and capture output."""
+    result = subprocess.run(
+        ["python3", script, "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def main():
+    root = Path(__file__).parent.parent
+    errors = []
+
+    # Check commitlint config
+    commitlint_path = root / ".commitlintrc.json"
+    if commitlint_path.exists():
+        expected = get_generated_content(root / "scripts" / "generate-commitlint-config.py")
+        actual = commitlint_path.read_text()
+
+        if expected.strip() != actual.strip():
+            errors.append(
+                ".commitlintrc.json out of sync. Run: python3 scripts/generate-commitlint-config.py"
+            )
+    else:
+        errors.append(
+            ".commitlintrc.json does not exist. Run: python3 scripts/generate-commitlint-config.py"
+        )
+
+    # Check cliff config
+    cliff_path = root / "cliff.toml"
+    if cliff_path.exists():
+        expected = get_generated_content(root / "scripts" / "generate-cliff-configs.py")
+        actual = cliff_path.read_text()
+
+        if expected.strip() != actual.strip():
+            errors.append(
+                "cliff.toml out of sync. Run: python3 scripts/generate-cliff-configs.py"
+            )
+    else:
+        errors.append(
+            "cliff.toml does not exist. Run: python3 scripts/generate-cliff-configs.py"
+        )
+
+    if errors:
+        print("Config sync check failed:\n")
+        for error in errors:
+            print(f"  - {error}\n")
+        sys.exit(1)
+    else:
+        print("All configs are in sync with commit-types.json")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-cliff-configs.py
+++ b/scripts/generate-cliff-configs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate cliff.toml configs from commit-types.json (single source of truth)."""
+
+import json
+import sys
+from pathlib import Path
+
+CHANGELOG_TEMPLATE = '''# git-cliff config for {name}
+# Auto-generated from commit-types.json - edit that file instead
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{{% if version %}}\\
+## [{{{{ version | trim_start_matches(pat="v") }}}}] - {{{{ timestamp | date(format="%Y-%m-%d") }}}}
+{{% else %}}\\
+## [unreleased]
+{{% endif %}}\\
+{{% for group, group_commits in commits | group_by(attribute="group") %}}\\
+{{% if group != "_ignored" %}}
+### {{{{ group | upper_first }}}}
+{{% for commit in group_commits %}}
+- {{{{ commit.message | upper_first }}}}
+{{% endfor %}}
+{{% endif %}}\\
+{{% endfor %}}\\
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+tag_pattern = "{tag_pattern}"
+commit_parsers = [
+{commit_parsers}
+]
+'''
+
+
+def generate_commit_parsers(types: dict) -> str:
+    """Generate commit_parsers array entries from types config."""
+    lines = []
+    for type_name, type_config in types.items():
+        group = type_config.get("changelog_group")
+        if group:
+            lines.append(f'    {{ message = "^{type_name}", group = "{group}" }},')
+    lines.append('    { message = ".*", group = "_ignored" },')
+    return "\n".join(lines)
+
+
+def main():
+    root = Path(__file__).parent.parent
+    config_path = root / "commit-types.json"
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    types = config["types"]
+    commit_parsers = generate_commit_parsers(types)
+    dry_run = "--dry-run" in sys.argv
+
+    output_path = root / "cliff.toml"
+    content = CHANGELOG_TEMPLATE.format(
+        name="repoverlay",
+        tag_pattern="v[0-9].*",
+        commit_parsers=commit_parsers,
+    )
+
+    if dry_run:
+        print(content)
+    else:
+        output_path.write_text(content)
+        print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-commitlint-config.py
+++ b/scripts/generate-commitlint-config.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Generate .commitlintrc.json from commit-types.json (single source of truth)."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).parent.parent
+    config_path = root / "commit-types.json"
+    output_path = root / ".commitlintrc.json"
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    types = list(config["types"].keys())
+
+    commitlint_config = {
+        "extends": ["@commitlint/config-conventional"],
+        "rules": {
+            "type-enum": [2, "always", types],
+            **config["commitlint_rules"],
+        },
+    }
+
+    output = json.dumps(commitlint_config, indent=2) + "\n"
+
+    if "--dry-run" in sys.argv:
+        print(output)
+    else:
+        output_path.write_text(output)
+        print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `commit-types.json` as single source of truth for commit types
- Add `.commitlintrc.json` for PR title validation
- Add `cliff.toml` for changelog generation with git-cliff
- Add scripts for config generation and sync checking:
  - `scripts/generate-cliff-configs.py`
  - `scripts/generate-commitlint-config.py`
  - `scripts/check-configs-sync.py`
