### PR TITLE
feat(cli): improve version string format for local builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::process::Command;
 use vergen::{BuildBuilder, Emitter};
 
@@ -8,6 +9,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Capture git info directly to avoid vergen-gitcl version conflicts
     emit_git_info();
+
+    // Detect CI builds via common environment variables
+    let is_ci = env::var("CI").is_ok()
+        || env::var("GITHUB_ACTIONS").is_ok()
+        || env::var("GITLAB_CI").is_ok()
+        || env::var("CIRCLECI").is_ok()
+        || env::var("TRAVIS").is_ok();
+    println!("cargo:rustc-env=REPOVERLAY_CI_BUILD={is_ci}");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Local builds now display version as `{version}-{branch} ({sha})` (e.g., `0.2.1-main (abc1234)`)
- Dirty working trees append `(dirty)` to the version string
- CI builds show only the clean version number (detected via common CI env vars)
