### PR TITLE
chore(deps): use crates.io version of tiny-update-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,8 @@ dependencies = [
 [[package]]
 name = "tiny-update-check"
 version = "0.1.0"
-source = "git+https://github.com/tylerbutler/tiny-update-check#f81a954dc7715b94c781294ebc9a1e7c069d4990"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5acedbb5e017cfcb45d7ec1b60415c7232dd481348734dbaeff4213cc1e7557"
 dependencies = [
  "dirs",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ crossterm = "0.29.0"
 sickle = { version = "0.1.2", features = ["serde"] }
 dirs = "6.0.0"
 fuzzy-matcher = "0.3"
-tiny-update-check = { git = "https://github.com/tylerbutler/tiny-update-check" }
+tiny-update-check = "0.1"
 
 [build-dependencies]
 vergen = { version = "9", features = ["build"] }


### PR DESCRIPTION
## Summary
- Switch tiny-update-check from git dependency to published crates.io version 0.1.x

## Test plan
- [x] `cargo check` passes