### PR TITLE
fix: prevent restore from re-applying explicitly removed overlays

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3699,4 +3699,235 @@ mod tests {
             assert!(result.is_none());
         }
     }
+
+    // Tests for restore_overlays
+    mod restore_overlays_tests {
+        use super::*;
+        use crate::state::{OverlayState, external_state_dir_for_target, load_external_states};
+        use crate::testutil::TestContext;
+
+        #[test]
+        fn does_not_restore_explicitly_removed_overlay() {
+            // This test verifies that `restore` does not re-apply overlays that were
+            // explicitly removed via `repoverlay remove`. The issue is that if external
+            // state exists but in-repo state was intentionally deleted (via remove command),
+            // restore should NOT re-apply the overlay.
+            //
+            // The fix marks external state with `removed_at` timestamp when an overlay
+            // is explicitly removed, so that `restore` knows to skip it.
+
+            let ctx = TestContext::new().with_overlay(&[(".envrc", "export FOO=bar")]);
+
+            // Use canonical path consistently (this is what restore_overlays does internally)
+            let canonical_repo_path = ctx.repo_path().canonicalize().unwrap();
+
+            // Step 1: Apply the overlay
+            apply_overlay(
+                ctx.overlay_source(),
+                ctx.repo_path(),
+                false, // use symlinks
+                None,  // auto-name
+                None,  // no ref override
+                false, // don't update cache
+                None,  // default source resolution
+                false, // not dry run
+            )
+            .expect("apply should succeed");
+
+            // Verify overlay was applied
+            assert!(
+                ctx.file_exists(".envrc"),
+                "overlay file should exist after apply"
+            );
+            assert!(
+                ctx.overlay_state_exists("test-overlay") || ctx.state_dir_exists(),
+                "in-repo state should exist"
+            );
+
+            // Verify external state was saved (before removal)
+            let ext_dir = external_state_dir_for_target(&canonical_repo_path).unwrap();
+            assert!(ext_dir.exists(), "external state directory should exist");
+
+            // Step 2: Remove the overlay (this simulates explicit user removal)
+            // This should mark the external state with `removed_at` instead of deleting it.
+            let applied = list_applied_overlays(ctx.repo_path()).expect("list should work");
+            assert!(
+                !applied.is_empty(),
+                "at least one overlay should be applied"
+            );
+            let overlay_name = &applied[0];
+
+            remove_overlay(ctx.repo_path(), Some(overlay_name.clone()), false, false)
+                .expect("remove should succeed");
+
+            // Verify overlay was removed from in-repo state
+            assert!(!ctx.file_exists(".envrc"), "overlay file should be removed");
+            assert!(
+                !ctx.overlay_state_exists(overlay_name),
+                "in-repo state should be removed"
+            );
+
+            // Verify external state file still exists (with removed_at marker)
+            let ext_state_file = ext_dir.join(format!("{overlay_name}.ccl"));
+            assert!(
+                ext_state_file.exists(),
+                "external state file should still exist (as tombstone)"
+            );
+
+            // Read the external state and verify it has removed_at set
+            let content = fs::read_to_string(&ext_state_file).unwrap();
+            let ext_state: OverlayState = sickle::from_str(&content).unwrap();
+            assert!(
+                ext_state.removed_at.is_some(),
+                "external state should have removed_at marker"
+            );
+
+            // Verify load_external_states skips removed overlays
+            let external_states =
+                load_external_states(&canonical_repo_path).expect("load should work");
+            assert_eq!(
+                external_states.len(),
+                0,
+                "load_external_states should skip removed overlays"
+            );
+
+            // Step 3: Call restore - this SHOULD NOT restore the overlay
+            // because it was explicitly removed (has removed_at marker).
+            restore_overlays(ctx.repo_path(), false).expect("restore should succeed");
+
+            // Step 4: Verify the overlay was NOT restored
+            assert!(
+                !ctx.file_exists(".envrc"),
+                "overlay file should NOT be restored after explicit removal"
+            );
+        }
+
+        #[test]
+        fn restores_overlay_after_git_clean() {
+            // This test verifies that `restore` DOES re-apply overlays when
+            // in-repo state is missing due to `git clean -fdx` (not explicit removal).
+            //
+            // The external state should NOT have `removed_at` set because the
+            // overlay was not explicitly removed.
+
+            let ctx = TestContext::new().with_overlay(&[(".envrc", "export FOO=bar")]);
+            let canonical_repo_path = ctx.repo_path().canonicalize().unwrap();
+
+            // Step 1: Apply the overlay
+            apply_overlay(
+                ctx.overlay_source(),
+                ctx.repo_path(),
+                false,
+                None,
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("apply should succeed");
+
+            let applied = list_applied_overlays(ctx.repo_path()).expect("list should work");
+            assert!(!applied.is_empty());
+
+            // Verify external state exists and doesn't have removed_at
+            let ext_states = load_external_states(&canonical_repo_path).unwrap();
+            assert_eq!(ext_states.len(), 1);
+            assert!(
+                ext_states[0].removed_at.is_none(),
+                "external state should NOT have removed_at"
+            );
+
+            // Step 2: Simulate `git clean -fdx` by removing only in-repo state
+            // This does NOT call remove_overlay, so external state stays intact.
+            fs::remove_dir_all(ctx.repo_path().join(".repoverlay")).unwrap();
+            // Also remove the overlay files (as git clean would)
+            fs::remove_file(ctx.repo_path().join(".envrc")).unwrap();
+
+            // Verify in-repo state is gone
+            assert!(!ctx.state_dir_exists(), "in-repo state should be removed");
+            assert!(
+                !ctx.file_exists(".envrc"),
+                "overlay files should be removed"
+            );
+
+            // External state should still be loadable (no removed_at marker)
+            let ext_states_after = load_external_states(&canonical_repo_path).unwrap();
+            assert_eq!(
+                ext_states_after.len(),
+                1,
+                "external state should still be loadable"
+            );
+
+            // Step 3: Call restore - this SHOULD restore the overlay
+            restore_overlays(ctx.repo_path(), false).expect("restore should succeed");
+
+            // Step 4: Verify the overlay WAS restored
+            assert!(
+                ctx.file_exists(".envrc"),
+                "overlay file should be restored after git clean"
+            );
+        }
+
+        #[test]
+        fn reapplying_overlay_clears_removed_marker() {
+            // This test verifies that re-applying an overlay clears the removed_at marker
+            // in case the user changes their mind after removal.
+
+            let ctx = TestContext::new().with_overlay(&[(".envrc", "export FOO=bar")]);
+            let canonical_repo_path = ctx.repo_path().canonicalize().unwrap();
+
+            // Step 1: Apply the overlay
+            apply_overlay(
+                ctx.overlay_source(),
+                ctx.repo_path(),
+                false,
+                None,
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("apply should succeed");
+
+            let applied = list_applied_overlays(ctx.repo_path()).expect("list should work");
+            let overlay_name = &applied[0];
+
+            // Step 2: Remove the overlay (marks removed_at)
+            remove_overlay(ctx.repo_path(), Some(overlay_name.clone()), false, false)
+                .expect("remove should succeed");
+
+            // Verify removed_at is set
+            let ext_dir = external_state_dir_for_target(&canonical_repo_path).unwrap();
+            let ext_state_file = ext_dir.join(format!("{overlay_name}.ccl"));
+            let content = fs::read_to_string(&ext_state_file).unwrap();
+            let ext_state: OverlayState = sickle::from_str(&content).unwrap();
+            assert!(ext_state.removed_at.is_some());
+
+            // Step 3: Re-apply the overlay
+            apply_overlay(
+                ctx.overlay_source(),
+                ctx.repo_path(),
+                false,
+                None,
+                None,
+                false,
+                None,
+                false,
+            )
+            .expect("re-apply should succeed");
+
+            // Step 4: Verify removed_at is cleared
+            let content_after = fs::read_to_string(&ext_state_file).unwrap();
+            let ext_state_after: OverlayState = sickle::from_str(&content_after).unwrap();
+            assert!(
+                ext_state_after.removed_at.is_none(),
+                "removed_at should be cleared after re-apply"
+            );
+
+            // Verify restore would now restore this overlay
+            // (if git clean happened again)
+            let ext_states = load_external_states(&canonical_repo_path).unwrap();
+            assert_eq!(ext_states.len(), 1, "external state should be loadable");
+        }
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -235,6 +235,10 @@ pub struct OverlayState {
     pub source: OverlaySource,
     #[serde(default)]
     pub files: Vec<FileEntry>,
+    /// When the overlay was explicitly removed (if set, overlay should not be restored).
+    /// This is only used in external state files to track removal intent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub removed_at: Option<DateTime<Utc>>,
 }
 
 impl OverlayState {
@@ -245,6 +249,7 @@ impl OverlayState {
             applied_at: Utc::now(),
             source,
             files: Vec::new(),
+            removed_at: None,
         }
     }
 
@@ -356,24 +361,25 @@ pub fn save_external_state(target: &Path, overlay_name: &str, state: &OverlaySta
     Ok(())
 }
 
-/// Remove overlay state from the external backup location.
+/// Mark overlay state as removed in the external backup location.
+///
+/// Instead of deleting the external state, we mark it with a `removed_at` timestamp.
+/// This allows `restore` to distinguish between overlays that were intentionally
+/// removed vs. those that are missing due to `git clean`.
 pub fn remove_external_state(target: &Path, overlay_name: &str) -> Result<()> {
     let dir = external_state_dir_for_target(target)?;
     let state_file = dir.join(format!("{overlay_name}.ccl"));
 
     if state_file.exists() {
-        fs::remove_file(&state_file)?;
-    }
-
-    // Clean up the directory if empty (except for the marker file)
-    if dir.exists() {
-        let remaining: Vec<_> = fs::read_dir(&dir)?
-            .filter_map(std::result::Result::ok)
-            .filter(|e| e.file_name() != ".target_path")
-            .collect();
-
-        if remaining.is_empty() {
-            fs::remove_dir_all(&dir)?;
+        // Read existing state and mark it as removed
+        let content = fs::read_to_string(&state_file)?;
+        if let Ok(mut state) = sickle::from_str::<OverlayState>(&content) {
+            state.removed_at = Some(Utc::now());
+            let updated_content = sickle::to_string(&state).context("Failed to serialize state")?;
+            fs::write(&state_file, updated_content)?;
+        } else {
+            // If we can't parse it, just delete it
+            fs::remove_file(&state_file)?;
         }
     }
 
@@ -381,6 +387,8 @@ pub fn remove_external_state(target: &Path, overlay_name: &str) -> Result<()> {
 }
 
 /// Load all overlay states from the external backup location for a target.
+///
+/// Only returns states that are eligible for restoration (not marked as removed).
 pub fn load_external_states(target: &Path) -> Result<Vec<OverlayState>> {
     debug!("load_external_states: {}", target.display());
     let dir = external_state_dir_for_target(target)?;
@@ -401,6 +409,14 @@ pub fn load_external_states(target: &Path) -> Result<Vec<OverlayState>> {
         {
             let content = fs::read_to_string(&path)?;
             if let Ok(state) = sickle::from_str::<OverlayState>(&content) {
+                // Skip overlays that were explicitly removed
+                if state.removed_at.is_some() {
+                    debug!(
+                        "skipping removed overlay '{}' (removed at {:?})",
+                        state.name, state.removed_at
+                    );
+                    continue;
+                }
                 states.push(state);
             }
         }
@@ -863,6 +879,7 @@ mod tests {
                     entry_type: EntryType::File,
                 },
             ],
+            removed_at: None,
         };
         let content = sickle::to_string(&state).unwrap();
         fs::write(overlays_dir.join("test-overlay.ccl"), content).unwrap();
@@ -1131,6 +1148,7 @@ mappings =
                     entry_type: EntryType::Directory,
                 },
             ],
+            removed_at: None,
         };
         let content = sickle::to_string(&state).unwrap();
         fs::write(overlays_dir.join("test-overlay.ccl"), content).unwrap();
@@ -1230,6 +1248,7 @@ directories =
             source,
             applied_at: chrono::Utc::now(),
             files: vec![],
+            removed_at: None,
         };
 
         let serialized = sickle::to_string(&state).unwrap();
@@ -1266,6 +1285,7 @@ directories =
             source,
             applied_at: chrono::Utc::now(),
             files: vec![],
+            removed_at: None,
         };
 
         let serialized = sickle::to_string(&state).unwrap();
@@ -1302,6 +1322,7 @@ directories =
             source: OverlaySource::local(PathBuf::from("/source")),
             applied_at: chrono::Utc::now(),
             files: vec![],
+            removed_at: None,
         };
         fs::write(
             ext_dir.join("valid.ccl"),


### PR DESCRIPTION
## Summary

- Fixes #64: `restore` command was re-applying overlays that were explicitly removed via `repoverlay remove`
- Adds `removed_at` timestamp field to track when an overlay was intentionally removed
- `load_external_states()` now skips overlays marked as removed
- Re-applying an overlay clears the removal marker

## Test plan

- [x] `does_not_restore_explicitly_removed_overlay` - verifies removed overlays are not restored
- [x] `restores_overlay_after_git_clean` - verifies overlays ARE restored after `git clean -fdx`
- [x] `reapplying_overlay_clears_removed_marker` - verifies re-applying clears the removal marker
- [x] All 70 existing tests pass
- [x] Clippy and format checks pass