### PR TITLE
feat: validate and expand source URLs at deserialization time

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -585,10 +585,14 @@ fn handle_source_command(command: SourceCommand) -> Result<()> {
                 anyhow::bail!("URL cannot be empty");
             }
 
-            // Extract name from URL if not provided
+            // Validate and normalize the URL (expands GitHub shorthand)
+            let validated_url =
+                config::validate_source_url(&url).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            // Extract name from validated URL if not provided
             let source_name = name.unwrap_or_else(|| {
-                // Try to extract repo name from URL
-                url.trim_end_matches('/')
+                validated_url
+                    .trim_end_matches('/')
                     .rsplit('/')
                     .next()
                     .unwrap_or("source")
@@ -610,7 +614,7 @@ fn handle_source_command(command: SourceCommand) -> Result<()> {
 
             let new_source = config::Source {
                 name: source_name.clone(),
-                url: url.clone(),
+                url: validated_url.clone(),
             };
 
             // Append to end of sources list
@@ -623,7 +627,7 @@ fn handle_source_command(command: SourceCommand) -> Result<()> {
                 source_name,
                 config.sources.len()
             );
-            println!("       URL: {url}");
+            println!("       URL: {validated_url}");
         }
         SourceCommand::List => {
             if config.sources.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@
 //! Per-repo config: `.repoverlay/config.ccl`
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -32,7 +32,56 @@ pub struct Source {
     /// Name for this source (used in CLI output and `--source` flag).
     pub name: String,
     /// Git URL of the overlay repository.
+    /// Accepts full URLs or GitHub shorthand (`owner/repo`), which is expanded
+    /// to `https://github.com/owner/repo` during deserialization.
+    #[serde(deserialize_with = "deserialize_source_url")]
     pub url: String,
+}
+
+/// Check if a string looks like a git-cloneable URL.
+fn is_git_url(s: &str) -> bool {
+    s.contains("://") || s.starts_with("git@")
+}
+
+/// Check if a string is valid GitHub shorthand (`owner/repo`).
+fn is_github_shorthand(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    parts.len() == 2
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && !parts[0].contains(char::is_whitespace)
+        && !parts[1].contains(char::is_whitespace)
+}
+
+/// Expand GitHub shorthand to a full URL.
+#[must_use]
+pub fn expand_github_shorthand(s: &str) -> String {
+    format!("https://github.com/{s}")
+}
+
+/// Validate and normalize a source URL string.
+///
+/// Accepts full git URLs or GitHub shorthand (`owner/repo`).
+/// Returns an error for invalid formats like bare words.
+pub fn validate_source_url(url: &str) -> std::result::Result<String, String> {
+    if is_git_url(url) {
+        Ok(url.to_string())
+    } else if is_github_shorthand(url) {
+        Ok(expand_github_shorthand(url))
+    } else {
+        Err(format!(
+            "Invalid source URL: '{url}'. Expected a git URL (https://...) or GitHub shorthand (owner/repo)."
+        ))
+    }
+}
+
+/// Custom deserializer that validates and expands source URLs.
+fn deserialize_source_url<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    validate_source_url(&raw).map_err(serde::de::Error::custom)
 }
 
 /// Configuration for a shared overlay repository.
@@ -865,5 +914,81 @@ sources =
 
         assert_eq!(source1, source2);
         assert_ne!(source1, source3);
+    }
+
+    // ==================== URL validation tests ====================
+
+    #[test]
+    fn test_validate_source_url_full_https() {
+        let result = validate_source_url("https://github.com/org/repo");
+        assert_eq!(result.unwrap(), "https://github.com/org/repo");
+    }
+
+    #[test]
+    fn test_validate_source_url_full_ssh() {
+        let result = validate_source_url("git@github.com:org/repo.git");
+        assert_eq!(result.unwrap(), "git@github.com:org/repo.git");
+    }
+
+    #[test]
+    fn test_validate_source_url_git_protocol() {
+        let result = validate_source_url("git://example.com/repo.git");
+        assert_eq!(result.unwrap(), "git://example.com/repo.git");
+    }
+
+    #[test]
+    fn test_validate_source_url_github_shorthand() {
+        let result = validate_source_url("tylerbutler/repo-overlays");
+        assert_eq!(
+            result.unwrap(),
+            "https://github.com/tylerbutler/repo-overlays"
+        );
+    }
+
+    #[test]
+    fn test_validate_source_url_bare_word_rejected() {
+        let result = validate_source_url("tylerbutler");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid source URL"));
+    }
+
+    #[test]
+    fn test_validate_source_url_empty_rejected() {
+        let result = validate_source_url("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_source_url_whitespace_rejected() {
+        let result = validate_source_url("owner /repo");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_source_with_github_shorthand() {
+        let ccl = r"
+sources =
+  =
+    name = personal
+    url = tylerbutler/repo-overlays
+";
+        let config: RepoverlayConfig = sickle::from_str(ccl).unwrap();
+        assert_eq!(config.sources.len(), 1);
+        assert_eq!(
+            config.sources[0].url,
+            "https://github.com/tylerbutler/repo-overlays"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_source_with_bare_word_fails() {
+        let ccl = r"
+sources =
+  =
+    name = personal
+    url = tylerbutler
+";
+        let result: std::result::Result<RepoverlayConfig, _> = sickle::from_str(ccl);
+        assert!(result.is_err());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1166,12 +1166,12 @@ fn source_add_rejects_empty_url() {
 #[test]
 fn source_add_rejects_trailing_slash_only_url() {
     let ctx = SourceTestContext::new();
-    // URL that results in empty name after parsing should be rejected
+    // "/" is not a valid URL or GitHub shorthand
     ctx.cmd()
         .args(["source", "add", "/"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Could not extract"));
+        .stderr(predicate::str::contains("Invalid source URL"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add URL validation to `Source` struct via custom serde deserializer that runs at config parse time
- Accept full git URLs (`https://`, `git@`, `git://`) and GitHub shorthand (`owner/repo`), auto-expanding shorthand to `https://github.com/owner/repo`
- Reject bare words and other invalid formats with a clear error message
- Apply the same validation in the `source add` CLI command