### PR TITLE
docs: add badges and streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # repoverlay
 
-Apply configuration files to git repositories without committing them.
+[![CI](https://github.com/tylerbutler/repoverlay/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tylerbutler/repoverlay/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/repoverlay)](https://crates.io/crates/repoverlay)
+[![codecov](https://codecov.io/gh/tylerbutler/repoverlay/graph/badge.svg)](https://codecov.io/gh/tylerbutler/repoverlay)
+[![MIT License](https://img.shields.io/crates/l/repoverlay)](LICENSE)
 
-Files are symlinked (or copied with `--copy`) from overlay sources and automatically excluded from git tracking via `.git/info/exclude`.
+Overlay config files into git repositories without committing them. Files are symlinked (or copied with `--copy`) from overlay sources and automatically excluded via `.git/info/exclude`.
 
 ## Quick Reference
 
@@ -12,7 +15,7 @@ Files are symlinked (or copied with `--copy`) from overlay sources and automatic
 | Check status | `repoverlay status` |
 | Remove overlay | `repoverlay remove <name>` |
 | Remove all | `repoverlay remove --all` |
-| Update from GitHub | `repoverlay update` |
+| Update from remote | `repoverlay update` |
 | Restore after git clean | `repoverlay restore` |
 | Create overlay | `repoverlay create <name>` |
 | Add files to overlay | `repoverlay add <name> <files>` |
@@ -39,24 +42,11 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/repoverlay/
 irm https://github.com/tylerbutler/repoverlay/releases/latest/download/repoverlay-installer.ps1 | iex
 ```
 
-### Cargo binstall
-
-```bash
-cargo binstall repoverlay
-```
-
 ### Cargo
 
 ```bash
-cargo install repoverlay
-```
-
-### From source
-
-```bash
-git clone https://github.com/tylerbutler/repoverlay
-cd repoverlay
-cargo install --path .
+cargo binstall repoverlay  # pre-built binary
+cargo install repoverlay   # build from source
 ```
 
 ## Usage
@@ -67,14 +57,10 @@ cargo install --path .
 # From local directory
 repoverlay apply /path/to/overlay
 
-# From GitHub (uses default branch)
+# From GitHub (default branch, specific ref, or subdirectory)
 repoverlay apply https://github.com/owner/repo
-
-# From GitHub with specific branch/tag
 repoverlay apply https://github.com/owner/repo/tree/v1.0.0
 repoverlay apply https://github.com/owner/repo --ref develop
-
-# From a subdirectory within a repo
 repoverlay apply https://github.com/owner/repo/tree/main/overlays/rust
 
 # From overlay repository
@@ -89,7 +75,7 @@ repoverlay apply ./overlay --name my-config         # Custom overlay name
 ### Remove overlays
 
 ```bash
-repoverlay remove              # Interactive (lists applied overlays)
+repoverlay remove              # Interactive selection
 repoverlay remove my-overlay   # Remove specific overlay
 repoverlay remove --all        # Remove all overlays
 ```
@@ -97,35 +83,33 @@ repoverlay remove --all        # Remove all overlays
 ### Check status
 
 ```bash
-repoverlay status                  # Show all applied overlays
-repoverlay status --name my-overlay # Show specific overlay
+repoverlay status                  # All applied overlays
+repoverlay status --name my-overlay # Specific overlay
 ```
 
-### Update GitHub overlays
+### Update remote overlays
 
 ```bash
-repoverlay update              # Check and apply updates to all GitHub overlays
-repoverlay update --dry-run    # Check without applying
+repoverlay update              # Pull and apply updates
+repoverlay update --dry-run    # Preview changes
 repoverlay update my-overlay   # Update specific overlay
 ```
 
 ### Restore after git clean
 
 ```bash
-repoverlay restore             # Restore overlays from external backup
+repoverlay restore             # Re-apply overlays from backup
 repoverlay restore --dry-run   # Preview what would be restored
 ```
 
 ### Create overlays
 
-Create overlays and store them in the overlay repository:
-
 ```bash
-# Short form: detect org/repo from git remote
-repoverlay create my-overlay                    # Creates org/repo/my-overlay
+# Detect org/repo from git remote
+repoverlay create my-overlay
 
-# Explicit form: specify full path
-repoverlay create microsoft/vscode/ai-config   # Creates microsoft/vscode/ai-config
+# Explicit path
+repoverlay create microsoft/vscode/ai-config
 
 # Include specific files
 repoverlay create my-overlay --include .claude/ --include CLAUDE.md
@@ -133,37 +117,27 @@ repoverlay create my-overlay --include .claude/ --include CLAUDE.md
 # Local output (no overlay repo)
 repoverlay create --local ./output --include .envrc
 
-# Preview what would be created
+# Preview / overwrite
 repoverlay create my-overlay --dry-run
-
-# Overwrite existing overlay
 repoverlay create my-overlay --force
 ```
 
 ### Add files to an existing overlay
 
-Add files to an overlay that's already applied:
-
 ```bash
-repoverlay add my-overlay newfile.txt              # Add single file
-repoverlay add my-overlay file1.txt file2.txt      # Add multiple files
-repoverlay add org/repo/my-overlay path/to/file    # Explicit overlay path
-repoverlay add my-overlay config.json --dry-run    # Preview without changes
+repoverlay add my-overlay newfile.txt              # Single file
+repoverlay add my-overlay file1.txt file2.txt      # Multiple files
+repoverlay add my-overlay config.json --dry-run    # Preview
 ```
 
-This copies files to the overlay repo, replaces the originals with symlinks, and automatically commits/pushes the changes.
+Copies files to the overlay source, replaces originals with symlinks, and auto-commits/pushes.
 
 ### Sync changes back
 
-After modifying files in an applied overlay, sync changes back to the overlay repo:
-
 ```bash
-repoverlay sync my-overlay          # Sync changes from applied overlay
-repoverlay sync org/repo/my-overlay # Explicit path
-repoverlay sync my-overlay --dry-run # Preview what would be synced
+repoverlay sync my-overlay          # Sync modified files back to source
+repoverlay sync my-overlay --dry-run
 ```
-
-The `create`, `add`, and `sync` commands automatically commit and push to the remote overlay repo.
 
 ### Switch overlays
 
@@ -172,21 +146,20 @@ Replace all existing overlays with a new one:
 ```bash
 repoverlay switch ~/overlays/typescript-ai
 repoverlay switch https://github.com/user/ai-configs/tree/main/rust
-repoverlay switch ~/overlays/new-config --name my-config
 ```
 
 ### Manage cache
 
 ```bash
-repoverlay cache list           # List cached repositories
-repoverlay cache path           # Show cache location
-repoverlay cache clear          # Clear entire cache
-repoverlay cache remove owner/repo  # Remove specific cached repo
+repoverlay cache list              # List cached repositories
+repoverlay cache path              # Show cache location
+repoverlay cache clear             # Clear entire cache
+repoverlay cache remove owner/repo # Remove specific cached repo
 ```
 
 ## Overlay Configuration
 
-Create a `repoverlay.ccl` in your overlay directory to configure it:
+Create a `repoverlay.ccl` in your overlay directory:
 
 ```
 overlay =
@@ -203,16 +176,11 @@ directories =
   = scratch
 ```
 
-### Configuration Options
+**`mappings`** — Rename files during apply (source = destination).
 
-**`overlay`** - Overlay metadata
-- `name` - Custom name for the overlay
+**`directories`** — Directories to symlink (or copy) as a unit rather than walking individual files. Useful for directories like `.claude/` that should be managed atomically.
 
-**`mappings`** - Rename files when applying (source = destination)
-
-**`directories`** - List of directories to symlink as a unit rather than walking individual files. Useful for directories like `.claude/` or `scratch/` that should be managed atomically. In copy mode (`--copy`), directories are recursively copied instead of symlinked.
-
-Without a config file, all files in the overlay directory are symlinked with the same relative path.
+Without a config file, all files are symlinked with the same relative path.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add CI build status, crates.io version, codecov coverage, and MIT license badges
- Consolidate cargo install methods into a single section
- Remove redundant section headers, comments, and prose throughout
- Tighten descriptions and examples for improved scannability
