### PR TITLE
feat(apply): auto-merge JSON files on cross-overlay conflicts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1162,7 +1162,7 @@ pub(crate) fn apply_resolved_overlay(
 
         // Check for conflicts with existing overlays
         if let Some(conflicting_overlay) = existing_targets.get(&target_rel_str) {
-            if merge && is_json_file(&target_rel) && target_file.exists() {
+            if is_json_file(&target_rel) && target_file.exists() {
                 eprintln!(
                     "  {} Merging '{}' (managed by overlay '{}')",
                     "Merge:".cyan(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1579,6 +1579,96 @@ fn repoverlay_merge_env_var_enables_merge() {
     assert_eq!(json["overlay"], true);
 }
 
+#[test]
+fn cross_overlay_json_auto_merges_without_merge_flag() {
+    let ctx = TestContext::new();
+    let overlay1 = common::create_overlay_dir(&[(
+        "settings.json",
+        r#"{"from_overlay1": true, "shared": "overlay1"}"#,
+    )]);
+    let overlay2 = common::create_overlay_dir(&[(
+        "settings.json",
+        r#"{"from_overlay2": true, "shared": "overlay2"}"#,
+    )]);
+
+    // Apply first overlay (copy mode for merge support)
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay1.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "first", "--copy"])
+        .assert()
+        .success();
+
+    // Apply second overlay WITHOUT --merge; should auto-merge the JSON
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay2.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "second", "--copy"])
+        .assert()
+        .success();
+
+    let content: serde_json::Value = serde_json::from_str(&ctx.read_file("settings.json")).unwrap();
+    assert_eq!(content["from_overlay1"], true); // preserved from first overlay
+    assert_eq!(content["from_overlay2"], true); // added from second overlay
+    assert_eq!(content["shared"], "overlay2"); // second overlay wins
+}
+
+#[test]
+fn cross_overlay_json_deep_merges_nested_objects() {
+    let ctx = TestContext::new();
+    let overlay1 = common::create_overlay_dir(&[(
+        "config.json",
+        r#"{"settings": {"theme": "dark", "font": "mono"}}"#,
+    )]);
+    let overlay2 = common::create_overlay_dir(&[(
+        "config.json",
+        r#"{"settings": {"font": "sans", "size": 14}}"#,
+    )]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay1.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "first", "--copy"])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay2.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "second", "--copy"])
+        .assert()
+        .success();
+
+    let content: serde_json::Value = serde_json::from_str(&ctx.read_file("config.json")).unwrap();
+    let settings = &content["settings"];
+    assert_eq!(settings["theme"], "dark"); // preserved from first
+    assert_eq!(settings["font"], "sans"); // second overlay wins
+    assert_eq!(settings["size"], 14); // added from second
+}
+
+#[test]
+fn cross_overlay_non_json_conflict_still_fails() {
+    let ctx = TestContext::new();
+    let overlay1 = common::create_overlay_dir(&[("config.txt", "from overlay1")]);
+    let overlay2 = common::create_overlay_dir(&[("config.txt", "from overlay2")]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay1.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "first", "--copy"])
+        .assert()
+        .success();
+
+    // Non-JSON cross-overlay conflict should still fail
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", overlay2.path().to_str().unwrap()])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .args(["--name", "second", "--copy"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already managed by overlay"));
+}
+
 // ─── Edit command tests ──────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- When applying an overlay with a JSON file already managed by another overlay, the files are now automatically deep-merged instead of erroring
- The `--merge` flag is still required for conflicts with existing repo files (not managed by overlays)
- Non-JSON file conflicts still produce errors (unchanged behavior)
- Closes #124

## Test plan
- [x] Existing tests pass (861 unit + 95 integration)
- [x] New test: cross-overlay JSON auto-merges without `--merge` flag
- [x] New test: cross-overlay nested JSON objects deep-merge correctly
- [x] New test: non-JSON cross-overlay conflicts still error
- [x] Existing test: repo-file JSON conflicts still require `--merge`