### PR TITLE
docs: update site styles and fonts

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -34,13 +34,14 @@ export default defineConfig({
 			customCss: [
 				"@fontsource/metropolis/400.css",
 				"@fontsource/metropolis/600.css",
-				// "./src/styles/custom.css",
+				"./src/styles/fonts.css",
+				"./src/styles/custom.css",
 			],
 			plugins: [
-				starlightCatppuccin({
-					dark: { flavor: "macchiato", accent: "maroon" },
-					light: { accent: "maroon" },
-				}),
+				// starlightCatppuccin({
+				// 	dark: { flavor: "macchiato", accent: "maroon" },
+				// 	light: { accent: "maroon" },
+				// }),
 				starlightLlmsTxt(),
 				starlightLinksValidator(),
 			],

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,8 +3,9 @@ title: repoverlay
 description: Overlay config files into git repositories without committing them.
 template: splash
 hero:
-  tagline: Overlay config files into git repositories without committing them. Symlink or copy shared configs — automatically excluded from git.
+  tagline: Overlay files into git repositories without committing them. Symlink or copy shared configs — automatically excluded from git.
   image:
+    alt: "the git logo overlaid on top of document icons"
     file: ../../assets/logo-large.webp
   actions:
     - text: Get started
@@ -14,20 +15,35 @@ hero:
     - text: What is repoverlay?
       link: /introduction/
       variant: secondary
+banner:
+  content: |
+    Reoverlay 0.7.0 is out now! This release adds all features intended for 1.0, plus fixes.
+    <a href="https://github.com/tylerbutler/repoverlay/releases/tag/v0.7.0">See the release notes</a>.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Features
 
+<style lang="css">{`
+  // Add a gradient to the heading on the splash page.
+  #_top {
+    background: linear-gradient(90deg, var(--sl-color-gray-2), var(--sl-color-accent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+`}
+</style>
+
 <CardGrid>
 	<Card title="Overlay without committing" icon="rocket">
-		Apply shared config files to any git repo. Files are automatically excluded via `.git/info/exclude` — no `.gitignore` changes needed.
+		Apply shared files to any git repo. Files are automatically excluded via `.git/info/exclude` — no `.gitignore` changes needed.
 	</Card>
 	<Card title="Symlink or copy" icon="setting">
 		Files are symlinked by default for instant updates, or use `--copy` when symlinks aren't suitable.
 	</Card>
-	<Card title="GitHub-native" icon="github">
+	<Card title="GitHub-aware" icon="github">
 		Pull overlays directly from GitHub repos, branches, tags, or subdirectories. Cached locally with shallow clones.
 	</Card>
 	<Card title="Fork inheritance" icon="random">

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,34 +1,30 @@
-:root {
-	--sl-font: "Metropolis", sans-serif;
-}
-
 /* Dark mode colors. */
 :root {
-	--sl-color-accent-low: #2b1d0e;
-	--sl-color-accent: #c47a1a;
-	--sl-color-accent-high: #f0d4a8;
+	--sl-color-accent-low: #371b14;
+	--sl-color-accent: #aa462c;
+	--sl-color-accent-high: #e5bfb4;
 	--sl-color-white: #ffffff;
-	--sl-color-gray-1: #fae3c3;
-	--sl-color-gray-2: #d4a86e;
-	--sl-color-gray-3: #a06b20;
-	--sl-color-gray-4: #6b4715;
-	--sl-color-gray-5: #43300f;
-	--sl-color-gray-6: #2e210a;
-	--sl-color-black: #1a1207;
+	--sl-color-gray-1: #ebedf9;
+	--sl-color-gray-2: #bfc1cf;
+	--sl-color-gray-3: #8789a4;
+	--sl-color-gray-4: #54566e;
+	--sl-color-gray-5: #34364d;
+	--sl-color-gray-6: #23243a;
+	--sl-color-black: #161721;
 }
 
 /* Light mode colors. */
-:root[data-theme="light"] {
-	--sl-color-accent-low: #f0dcc4;
-	--sl-color-accent: #8b5a1b;
-	--sl-color-accent-high: #3a250d;
-	--sl-color-white: #1a1207;
-	--sl-color-gray-1: #2e210a;
-	--sl-color-gray-2: #43300f;
-	--sl-color-gray-3: #6b4715;
-	--sl-color-gray-4: #a06b20;
-	--sl-color-gray-5: #d4a86e;
-	--sl-color-gray-6: #fae3c3;
-	--sl-color-gray-7: #fdf3e6;
+:root[data-theme='light'] {
+	--sl-color-accent-low: #edcfc8;
+	--sl-color-accent: #ac482e;
+	--sl-color-accent-high: #4f2418;
+	--sl-color-white: #161721;
+	--sl-color-gray-1: #23243a;
+	--sl-color-gray-2: #34364d;
+	--sl-color-gray-3: #54566e;
+	--sl-color-gray-4: #8789a4;
+	--sl-color-gray-5: #bfc1cf;
+	--sl-color-gray-6: #ebedf9;
+	--sl-color-gray-7: #f5f6fc;
 	--sl-color-black: #ffffff;
 }

--- a/website/src/styles/fonts.css
+++ b/website/src/styles/fonts.css
@@ -1,0 +1,3 @@
+:root {
+	--sl-font: "Metropolis", sans-serif;
+}


### PR DESCRIPTION
## Summary
- Refreshed documentation website with new color scheme (dark and light modes)
- Reorganized CSS: extracted font declarations to separate fonts.css file
- Re-enabled custom styles in astro.config.mjs, disabled Catppuccin plugin
- Enhanced splash page with gradient text effect on hero heading
- Added release announcement banner for v0.7.0
- Improved copy clarity (hero tagline, "GitHub-aware" terminology)