### PR TITLE
chore: preserve newlines in changie changeFormat

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -11,7 +11,7 @@ kindFormat: '#### {{.Kind}}'
 changeFormat: |-
     ##### {{(splitn "\n" 2 .Body)._0}}
     {{with (splitn "\n" 2 .Body)._1 | default "" | trim}}
-    {{. | replace "\n\n" "<<PARA>>" | replace "\n" " " | replace "<<PARA>>" "\n\n"}}
+    {{.}}
     {{end}}
 body:
     block: true


### PR DESCRIPTION
## Summary

- Stop collapsing single newlines into spaces in changelog body text
- The old `replace "\n" " "` pipeline destroyed markdown list formatting by joining list items into a single line

## Test plan
- [ ] Verify `changie batch auto --dry-run` preserves list formatting in entries