### PR TITLE
ci: switch from PAT to GitHub App for release workflows

### DIFF
--- a/.github/workflows/changie-release.yml
+++ b/.github/workflows/changie-release.yml
@@ -5,22 +5,25 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: tylerbutler/actions/changie-release@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           version-files: 'Cargo.toml:version'
 
       # Update Cargo.lock to match the version bumped by changie-release

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,11 +17,19 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/setup-rust
 
@@ -30,5 +38,5 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `RELEASE_PAT` in changie-release workflow with GitHub App token via `actions/create-github-app-token`
- Replace `RELEASE_PLZ_TOKEN` in release-plz workflow with the same GitHub App token
- Remove `permissions` block from changie-release (app token carries its own scoped permissions)

## Secrets required

Configure these repository secrets:
- `RELEASE_APP_ID` — GitHub App ID
- `RELEASE_APP_PRIVATE_KEY` — GitHub App private key

## Secrets to remove (after verifying)

- `RELEASE_PAT`
- `RELEASE_PLZ_TOKEN`

## Test plan

- [ ] Verify `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` secrets are configured
- [ ] Merge and confirm changie-release workflow creates release PR successfully
- [ ] Confirm release-plz tags and publishes correctly