### PR TITLE
fix: unwrap hard line breaks in changelog release notes

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -11,7 +11,7 @@ kindFormat: '#### {{.Kind}}'
 changeFormat: |-
     ##### {{(splitn "\n" 2 .Body)._0}}
     {{with (splitn "\n" 2 .Body)._1 | default "" | trim}}
-    {{.}}
+    {{regexReplaceAll "([^\n])\n([^\n])" . "${1} ${2}"}}
     {{end}}
 body:
     block: true


### PR DESCRIPTION
## Summary

- Modifies the changie `changeFormat` template to unwrap hard line breaks within paragraphs using `regexReplaceAll`
- Single newlines between non-newline characters are replaced with spaces; double newlines (paragraph breaks) are preserved
- Fixes GitHub release notes rendering broken by mid-paragraph line breaks from text-wrapped changie entries

## Test plan

- [ ] Create a test changie entry with hard-wrapped text (`changie new`) and verify `changie batch` produces unwrapped paragraphs
- [ ] Verify paragraph breaks (double newlines) are still preserved in output