### PR TITLE
fix(sync): use state org/repo for upstream-resolved overlays

### DIFF
--- a/.changes/unreleased/sync-Fixed-20260305-141837.yaml
+++ b/.changes/unreleased/sync-Fixed-20260305-141837.yaml
@@ -1,0 +1,6 @@
+component: sync
+kind: Fixed
+body: |-
+    Fix `sync <name>` using wrong org/repo for overlays applied via upstream fallback
+    When syncing a single overlay by name in a fork repository, the sync command detected the org/repo from the git remote (e.g., `alexvy86/FluidFramework`) instead of using the org/repo saved in the overlay state (e.g., `microsoft/FluidFramework`). This caused sync to fail with "does not exist in overlay repo" because the fork's org/repo path doesn't exist in the overlay repo. Now uses the org/repo from the saved state, matching the behavior of `sync --all`.
+time: 2026-03-05T14:18:37.154401-08:00

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1952,7 +1952,8 @@ fn handle_sync(
         println!("{check} Synced {synced} overlay(s), skipped {skipped}");
     } else if let Some(name_arg) = name {
         // Parse the name argument to get org/repo/name
-        let (org, repo, overlay_name) = parse_overlay_name_arg(&name_arg, &target)?;
+        let (detected_org, detected_repo, overlay_name) =
+            parse_overlay_name_arg(&name_arg, &target)?;
 
         // Verify the overlay is currently applied
         let normalized_name = normalize_overlay_name(&overlay_name)?;
@@ -1964,7 +1965,7 @@ fn handle_sync(
         {
             bail!(
                 "Overlay '{overlay_name}' is not currently applied.\n\n\
-                 To apply it first: repoverlay apply {org}/{repo}/{overlay_name}"
+                 To apply it first: repoverlay apply {detected_org}/{detected_repo}/{overlay_name}"
             );
         }
 
@@ -1983,6 +1984,17 @@ fn handle_sync(
                 );
             }
         }
+
+        // Use org/repo from saved state rather than git remote detection.
+        // When an overlay was applied via upstream fallback (e.g., fork
+        // alexvy86/FluidFramework resolved to upstream microsoft/FluidFramework),
+        // the state records the correct upstream org/repo. Using the git-remote-
+        // detected org/repo would point to the fork path which doesn't exist
+        // in the overlay repo.
+        let (org, repo) = match &state.source {
+            OverlaySource::OverlayRepo { org, repo, .. } => (org.clone(), repo.clone()),
+            _ => (detected_org, detected_repo),
+        };
 
         // Load overlay repo config (respects source_name for multi-source configs, #147)
         let config = load_config(None)?;


### PR DESCRIPTION
## Summary

- Fixes `repoverlay sync <name>` failing with "does not exist in overlay repo" when the overlay was applied via upstream fallback (e.g., in a fork)
- The sync command was detecting org/repo from the git remote (fork org) instead of using the org/repo saved in the overlay state (upstream org)
- Now reads org/repo from the saved state for OverlayRepo sources, matching the existing behavior of `sync --all`

## Reproduction

1. Configure a source pointing to an overlay repo (e.g., `alexvy86/repo-overlays`)
2. In a fork repo (e.g., `alexvy86/FluidFramework` forking `microsoft/FluidFramework`), apply an overlay: `repoverlay apply alexvy86/FluidFramework/ai-config`
3. The apply succeeds, resolving via upstream to `microsoft/FluidFramework/ai-config`
4. Run `repoverlay sync ai-config` — fails with: `Error: 'alexvy86/FluidFramework/ai-config' does not exist in overlay repo`

## Root cause

In `handle_sync`, when the user provides just the overlay name (no slashes), `parse_overlay_name_arg` calls `detect_target_repo` which reads the git remote URL. In a fork, this returns the fork's org/repo (`alexvy86/FluidFramework`), not the upstream org/repo (`microsoft/FluidFramework`) that the overlay was actually stored under.

The `sync --all` path already correctly reads org/repo from the saved state. The single-name path now does the same.

## Test plan

- [x] All 106 existing tests pass
- [x] `cargo clippy` clean
- [ ] Manual test: apply overlay via upstream fallback in a fork, then sync by name