### PR TITLE
docs: add manual test cases for edit, sync, cache, and completions

### DIFF
--- a/docs/manual-tests/FLEET-PROMPT.md
+++ b/docs/manual-tests/FLEET-PROMPT.md
@@ -1,0 +1,84 @@
+Run the manual test suite for the `repoverlay` CLI tool. The test cases are in
+`docs/manual-tests/`. Each `.md` file covers one command or group of commands.
+
+## Step 1: Build
+
+Build the project first:
+
+```
+cargo build --release
+```
+
+The binary will be at `target/release/repoverlay`.
+
+## Step 2: Dispatch test agents
+
+Dispatch one agent per test file, **all in parallel**. Each agent should:
+
+1. Set up its environment:
+   ```bash
+   export PATH="<repo-root>/target/release:$PATH"
+   export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@test.com"
+   export GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@test.com"
+   ```
+
+2. Read its assigned test file from `docs/manual-tests/`.
+
+3. Run the **Setup** section once, then execute each **TC-xx** test case in
+   order:
+   - Run the **Steps** commands exactly as written.
+   - Run all **Verify** commands and compare actual output against expected.
+   - Record **PASS** or **FAIL** with details for each TC.
+
+4. **Skip** any test case marked `(Optional, requires network)` or
+   `(requires network)` unless you have been told network access is available.
+
+5. Run the **Cleanup** section at the end.
+
+6. Return a summary table:
+   ```
+   | TC-ID | Name | PASS/FAIL | Details (if failed) |
+   ```
+
+Here are the test files to dispatch (one agent each):
+
+| Agent | File | Description |
+|-------|------|-------------|
+| 1 | `docs/manual-tests/apply.md` | Apply overlays (symlink, copy, dry-run, force, merge) |
+| 2 | `docs/manual-tests/create.md` | Create overlays from repos |
+| 3 | `docs/manual-tests/remove.md` | Remove applied overlays |
+| 4 | `docs/manual-tests/restore.md` | Restore overlays after deletion |
+| 5 | `docs/manual-tests/status.md` | Status display and filtering |
+| 6 | `docs/manual-tests/switch-browse.md` | Switch overlays and browse sources |
+| 7 | `docs/manual-tests/update.md` | Update overlays from sources |
+| 8 | `docs/manual-tests/edit.md` | Edit add/remove files in overlays |
+| 9 | `docs/manual-tests/sync.md` | Sync changes back to overlay source |
+| 10 | `docs/manual-tests/source-management.md` | Manage overlay sources |
+| 11 | `docs/manual-tests/cache.md` | Cache management |
+| 12 | `docs/manual-tests/completions.md` | Shell completion generation |
+
+## Step 3: Collect results and file issues
+
+After all agents complete:
+
+1. Compile a combined results table across all test suites.
+2. For each **FAIL**, determine if it is:
+   - **A product bug** — unexpected behavior or crash.
+   - **A test case bug** — the test expectations don't match intended behavior.
+   - **A known issue** — already documented in the test file with an issue link.
+3. File a GitHub issue for each **new product bug** found, including:
+   - The test case ID and file.
+   - Exact reproduction steps (from the test case).
+   - Expected vs. actual output.
+   - Exit codes.
+4. Print a final summary:
+   ```
+   ## Results
+   - Total: XX test cases
+   - Passed: XX
+   - Failed: XX
+   - Skipped: XX (network-dependent)
+
+   ## Issues Filed
+   | # | Title | Label |
+   ```

--- a/docs/manual-tests/cache.md
+++ b/docs/manual-tests/cache.md
@@ -1,0 +1,125 @@
+# Cache - Manual Test
+
+## Prerequisites
+
+- `repoverlay` installed and on PATH
+
+## Setup
+
+No special setup is needed — cache commands operate on the global cache directory.
+
+## Test Cases
+
+### TC-01: Show cache path
+
+**Steps:**
+
+```bash
+repoverlay cache path
+```
+
+**Expected Output:**
+
+- Prints the absolute path to the cache directory (e.g., `~/.cache/repoverlay`)
+
+**Verify:**
+
+```bash
+CACHE_PATH=$(repoverlay cache path)
+echo "$CACHE_PATH"
+# Should be a valid absolute path
+# Path should end with "repoverlay" or similar
+```
+
+### TC-02: List cached repositories (empty cache)
+
+**Steps:**
+
+```bash
+repoverlay cache list
+```
+
+**Expected Output:**
+
+- Message indicating no cached repositories, or an empty list
+
+**Verify:**
+
+```bash
+repoverlay cache list
+echo "Exit code: $?"
+# Exit code should be 0 (not an error to have an empty cache)
+```
+
+### TC-03: Remove with --all on empty cache
+
+**Steps:**
+
+```bash
+repoverlay cache remove --all --yes
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Message indicating cache cleared or no cached repositories to remove
+- Exit code 0
+
+### TC-04 (Optional, requires network): Cache populated after GitHub apply
+
+**Steps:**
+
+```bash
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+mkdir target-repo && cd target-repo
+git init
+git commit --allow-empty -m "init"
+cd "$TEST_DIR"
+
+# Replace with a real public overlay repository URL
+repoverlay apply https://github.com/OWNER/REPO --target ./target-repo
+
+repoverlay cache list
+```
+
+**Expected Output:**
+
+- Cache list shows the cloned GitHub repository
+- Displays owner/repo, ref, commit hash, and fetched timestamp
+
+**Verify:**
+
+```bash
+CACHE_PATH=$(repoverlay cache path)
+ls "$CACHE_PATH"
+# Should contain a directory for the cached repository
+```
+
+### TC-05 (Optional, requires network): Remove specific cached repository
+
+**Steps:**
+
+```bash
+# Assumes TC-04 has populated the cache with OWNER/REPO
+repoverlay cache remove OWNER/REPO
+```
+
+**Expected Output:**
+
+- Success message indicating the repository was removed from cache
+
+**Verify:**
+
+```bash
+repoverlay cache list
+# Should no longer show the removed repository
+```
+
+## Cleanup
+
+```bash
+# Only if TC-04/TC-05 were run
+rm -rf "$TEST_DIR"
+```

--- a/docs/manual-tests/completions.md
+++ b/docs/manual-tests/completions.md
@@ -1,0 +1,117 @@
+# Completions - Manual Test
+
+## Prerequisites
+
+- `repoverlay` installed and on PATH
+
+## Test Cases
+
+### TC-01: Generate bash completions
+
+**Steps:**
+
+```bash
+repoverlay completions bash
+```
+
+**Expected Output:**
+
+- Shell completion script printed to stdout
+- Script should be valid bash syntax
+
+**Verify:**
+
+```bash
+repoverlay completions bash > /dev/null
+echo "Exit code: $?"
+# Exit code should be 0
+
+repoverlay completions bash | head -5
+# Should contain bash completion function definitions
+
+repoverlay completions bash | grep -q "repoverlay"
+echo "Contains repoverlay: $?"
+# Should be 0 (completions reference the command name)
+```
+
+### TC-02: Generate zsh completions
+
+**Steps:**
+
+```bash
+repoverlay completions zsh
+```
+
+**Expected Output:**
+
+- Zsh completion script printed to stdout
+
+**Verify:**
+
+```bash
+repoverlay completions zsh > /dev/null
+echo "Exit code: $?"
+# Exit code should be 0
+
+repoverlay completions zsh | grep -q "repoverlay"
+echo "Contains repoverlay: $?"
+# Should be 0
+```
+
+### TC-03: Generate fish completions
+
+**Steps:**
+
+```bash
+repoverlay completions fish
+```
+
+**Expected Output:**
+
+- Fish shell completion script printed to stdout
+
+**Verify:**
+
+```bash
+repoverlay completions fish > /dev/null
+echo "Exit code: $?"
+# Exit code should be 0
+
+repoverlay completions fish | grep -q "repoverlay"
+echo "Contains repoverlay: $?"
+# Should be 0
+```
+
+### TC-04: Generate completions for all supported shells
+
+**Steps:**
+
+```bash
+for shell in bash elvish fish powershell zsh; do
+  repoverlay completions "$shell" > /dev/null 2>&1
+  echo "$shell: exit code $?"
+done
+```
+
+**Expected Output:**
+
+- Exit code 0 for each supported shell
+
+### TC-05: Invalid shell name
+
+**Steps:**
+
+```bash
+repoverlay completions invalid-shell 2>&1
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating invalid shell name
+- Non-zero exit code
+- Should list valid shell options
+
+## Cleanup
+
+No cleanup needed — completions are printed to stdout only.

--- a/docs/manual-tests/edit.md
+++ b/docs/manual-tests/edit.md
@@ -1,0 +1,216 @@
+# Edit - Manual Test
+
+## Prerequisites
+
+- `repoverlay` installed and on PATH
+- `git` installed
+
+## Setup
+
+> **Note:** `edit add` currently requires the target repository to have a git
+> remote origin, even for locally-applied overlays. See
+> [#204](https://github.com/tylerbutler/repoverlay/issues/204). The setup
+> below includes a fake remote to work around this.
+
+```bash
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+# Create a target git repository with some existing files
+mkdir target-repo && cd target-repo
+git init
+git remote add origin https://github.com/example/repo.git
+git commit --allow-empty -m "init"
+echo "app config" > .app-config
+echo "editor prefs" > .editorconfig
+git add . && git commit -m "add config files"
+cd "$TEST_DIR"
+
+# Create a local overlay with one file
+mkdir -p my-overlay
+cat > my-overlay/repoverlay.ccl << 'CCL'
+overlay =
+  name = my-overlay
+CCL
+echo "overlay env" > my-overlay/.envrc
+
+# Apply the overlay to the target repo
+repoverlay apply ./my-overlay --target ./target-repo
+```
+
+## Test Cases
+
+### TC-01: Add a file to an applied overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit add my-overlay .app-config --target ./target-repo
+```
+
+**Expected Output:**
+
+- Success message indicating file added to overlay
+- File in target repo replaced with symlink to overlay source
+
+**Verify:**
+
+```bash
+ls -la "$TEST_DIR/target-repo/.app-config"
+# Should be a symlink pointing to the overlay source
+
+ls "$TEST_DIR/my-overlay/.app-config"
+# Should exist in the overlay source directory
+
+repoverlay status --target "$TEST_DIR/target-repo"
+# Should show .app-config as part of my-overlay's files
+```
+
+### TC-02: Add multiple files to an applied overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+# Create additional files in the target repo
+echo "tool versions" > "$TEST_DIR/target-repo/.tool-versions"
+echo "prettierrc" > "$TEST_DIR/target-repo/.prettierrc"
+
+repoverlay edit add my-overlay .tool-versions .prettierrc --target ./target-repo
+```
+
+**Expected Output:**
+
+- Success message indicating both files added to overlay
+
+**Verify:**
+
+```bash
+ls "$TEST_DIR/my-overlay/.tool-versions"
+# Should exist in overlay source
+
+ls "$TEST_DIR/my-overlay/.prettierrc"
+# Should exist in overlay source
+
+ls -la "$TEST_DIR/target-repo/.tool-versions"
+# Should be a symlink
+
+ls -la "$TEST_DIR/target-repo/.prettierrc"
+# Should be a symlink
+```
+
+### TC-03: Remove a file from an applied overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit remove my-overlay .prettierrc --target ./target-repo
+```
+
+**Expected Output:**
+
+- Success message indicating file removed from overlay
+
+**Verify:**
+
+```bash
+ls "$TEST_DIR/target-repo/.prettierrc" 2>&1
+# Should report "No such file or directory" — symlink removed from target
+
+repoverlay status --target "$TEST_DIR/target-repo"
+# Should NOT list .prettierrc in my-overlay's files
+
+ls "$TEST_DIR/my-overlay/.prettierrc"
+# File is preserved in the overlay source directory (not deleted)
+```
+
+### TC-04: Add with --dry-run
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit add my-overlay .editorconfig --target ./target-repo --dry-run
+```
+
+**Expected Output:**
+
+- Shows what would be added without making changes
+
+**Verify:**
+
+```bash
+ls -la "$TEST_DIR/target-repo/.editorconfig"
+# Should still be a regular file, NOT a symlink
+
+ls "$TEST_DIR/my-overlay/.editorconfig" 2>&1
+# Should report "No such file or directory" — not copied to overlay source
+```
+
+### TC-05: Remove with --dry-run
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit remove my-overlay .tool-versions --target ./target-repo --dry-run
+```
+
+**Expected Output:**
+
+- Shows what would be removed without making changes
+
+**Verify:**
+
+```bash
+ls "$TEST_DIR/my-overlay/.tool-versions"
+# Should still exist in overlay source
+
+ls -la "$TEST_DIR/target-repo/.tool-versions"
+# Should still be a symlink — dry-run made no changes
+```
+
+### TC-06: Add a file that doesn't exist in target repo
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit add my-overlay nonexistent.txt --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating file does not exist
+- Non-zero exit code
+
+### TC-07: Remove a file not managed by the overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay edit remove my-overlay not-in-overlay.txt --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating file is not managed by the overlay
+- Non-zero exit code
+
+## Cleanup
+
+```bash
+rm -rf "$TEST_DIR"
+```

--- a/docs/manual-tests/sync.md
+++ b/docs/manual-tests/sync.md
@@ -1,0 +1,170 @@
+# Sync - Manual Test
+
+## Prerequisites
+
+- `repoverlay` installed and on PATH
+- `git` installed
+
+> **Note:** `sync` only works with overlays applied from an overlay repo source
+> (e.g., `org/repo/name` format). Overlays applied directly from local paths
+> (`./my-overlay`) are not syncable. TC-01 through TC-03 verify this constraint,
+> while TC-04 and TC-05 test error handling.
+>
+> The `sync` command also requires the target repository to have a git remote
+> origin for org/repo detection.
+
+## Setup
+
+```bash
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+
+# Create a target git repository (with a fake remote for sync's org/repo detection)
+mkdir target-repo && cd target-repo
+git init
+git remote add origin https://github.com/example/repo.git
+git commit --allow-empty -m "init"
+cd "$TEST_DIR"
+
+# Create a local overlay
+mkdir -p my-overlay
+cat > my-overlay/repoverlay.ccl << 'CCL'
+overlay =
+  name = my-overlay
+CCL
+echo "original content" > my-overlay/.config
+
+# Initialize overlay as a git repo (sync commits changes back)
+cd my-overlay
+git init
+git add . && git commit -m "init overlay"
+cd "$TEST_DIR"
+
+# Apply the overlay to the target repo
+repoverlay apply ./my-overlay --target ./target-repo
+```
+
+## Test Cases
+
+### TC-01: Sync rejects locally-applied overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay sync my-overlay --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating local source overlays cannot be synced
+- Non-zero exit code
+
+**Verify:**
+
+```bash
+repoverlay status --target "$TEST_DIR/target-repo"
+# Should show my-overlay still applied (unchanged)
+```
+
+### TC-02: Sync --dry-run rejects locally-applied overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay sync my-overlay --target ./target-repo --dry-run
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating local source cannot be synced
+- Non-zero exit code
+
+### TC-03: Sync --all with only local overlays applied
+
+> **Known issue:** [#205](https://github.com/tylerbutler/repoverlay/issues/205) —
+> `sync --all` does not gracefully skip local-source overlays.
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+# Create and apply a second local overlay
+mkdir -p other-overlay
+cat > other-overlay/repoverlay.ccl << 'CCL'
+overlay =
+  name = other-overlay
+CCL
+echo "other content" > other-overlay/.other
+
+cd other-overlay
+git init
+git add . && git commit -m "init other overlay"
+cd "$TEST_DIR"
+
+repoverlay apply ./other-overlay --target ./target-repo
+
+repoverlay sync --all --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output (after #205 is fixed):**
+
+- Messages indicating each overlay skipped (local sources not syncable)
+- Summary like "Synced 0 overlay(s), skipped 2"
+
+**Current Output:**
+
+- `Error: Failed to pull overlay repository` — attempts remote pull instead of skipping
+- Non-zero exit code
+
+**Verify:**
+
+```bash
+repoverlay status --target "$TEST_DIR/target-repo"
+# Should show both overlays still applied (unchanged)
+```
+
+### TC-04: Sync non-existent overlay
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay sync does-not-exist --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating overlay is not applied
+- Non-zero exit code
+
+### TC-05: Sync with no overlay name and no --all
+
+**Steps:**
+
+```bash
+cd "$TEST_DIR"
+
+repoverlay sync --target ./target-repo
+echo "Exit code: $?"
+```
+
+**Expected Output:**
+
+- Error message indicating overlay name is required or --all must be used
+- Non-zero exit code, OR selects the single applied overlay if only one exists
+
+## Cleanup
+
+```bash
+rm -rf "$TEST_DIR"
+```


### PR DESCRIPTION
## Summary

Adds comprehensive manual test documentation for the 4 CLI commands that were missing test coverage, bringing all 13 commands to full manual test coverage.

## New files

| File | Command | Test Cases |
|------|---------|------------|
| `docs/manual-tests/edit.md` | `edit add`, `edit remove` | 7 TCs — add/remove files, dry-run, error handling |
| `docs/manual-tests/sync.md` | `sync` | 5 TCs — sync, --all, --dry-run, error handling |
| `docs/manual-tests/cache.md` | `cache` | 5 TCs — path, list, remove (network tests marked) |
| `docs/manual-tests/completions.md` | `completions` | 5 TCs — bash/zsh/fish/elvish/powershell, invalid shell |

## Validation

All test cases were executed against the current build. Known issues discovered during testing are documented inline with links to filed issues:

- `edit.md` references #204 (`edit add` requires git remote for local overlays)
- `sync.md` references #205 (`sync --all` does not skip local overlays gracefully)

## Format

All test cases follow the existing manual test format with Prerequisites, Setup, Steps, Expected Output, Verify, and Cleanup sections.