### PR TITLE
fix: log warnings on corrupted .ccl state file parse errors

### DIFF
--- a/.changes/unreleased/fixes-Fixed-20260411-144545.yaml
+++ b/.changes/unreleased/fixes-Fixed-20260411-144545.yaml
@@ -1,0 +1,7 @@
+component: fixes
+kind: Fixed
+body: |-
+    Log warnings when .ccl state files fail to parse instead of silently skipping
+
+    Previously, corrupted or unparseable .ccl state files were silently ignored. Now repoverlay logs a warning message identifying the problematic file before skipping it, making it easier to diagnose configuration issues.
+time: 2026-04-11T14:45:45.060849-07:00

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 "cargo:cargo-audit" = "0.22.1"
+"cargo:cargo-deny" = "0.19.0"
 changie = "latest"
 "github:cargo-bins/cargo-binstall" = "1.17.9"
 hk = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+"cargo:cargo-audit" = "0.22.1"
 changie = "latest"
 "github:cargo-bins/cargo-binstall" = "1.17.9"
 hk = "latest"

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
-use log::debug;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::fs;
@@ -594,13 +594,20 @@ pub(crate) fn remove_external_state(target: &Path, overlay_name: &str) -> Result
     if state_file.exists() {
         // Read existing state and mark it as removed
         let content = fs::read_to_string(&state_file)?;
-        if let Ok(mut state) = sickle::from_str::<OverlayState>(&content) {
-            state.removed_at = Some(Utc::now());
-            let updated_content = sickle::to_string(&state).context("Failed to serialize state")?;
-            fs::write(&state_file, updated_content)?;
-        } else {
-            // If we can't parse it, just delete it
-            fs::remove_file(&state_file)?;
+        match sickle::from_str::<OverlayState>(&content) {
+            Ok(mut state) => {
+                state.removed_at = Some(Utc::now());
+                let updated_content =
+                    sickle::to_string(&state).context("Failed to serialize state")?;
+                fs::write(&state_file, updated_content)?;
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to parse state file {}, deleting it: {e}",
+                    state_file.display()
+                );
+                fs::remove_file(&state_file)?;
+            }
         }
     }
 
@@ -629,16 +636,21 @@ pub(crate) fn load_external_states(target: &Path) -> Result<Vec<OverlayState>> {
             && path.file_name() != Some(std::ffi::OsStr::new(".target_path"))
         {
             let content = fs::read_to_string(&path)?;
-            if let Ok(state) = sickle::from_str::<OverlayState>(&content) {
-                // Skip overlays that were explicitly removed
-                if state.removed_at.is_some() {
-                    debug!(
-                        "skipping removed overlay '{}' (removed at {:?})",
-                        state.name, state.removed_at
-                    );
-                    continue;
+            match sickle::from_str::<OverlayState>(&content) {
+                Ok(state) => {
+                    // Skip overlays that were explicitly removed
+                    if state.removed_at.is_some() {
+                        debug!(
+                            "skipping removed overlay '{}' (removed at {:?})",
+                            state.name, state.removed_at
+                        );
+                        continue;
+                    }
+                    states.push(state);
                 }
-                states.push(state);
+                Err(e) => {
+                    warn!("Failed to parse state file {}: {e}", path.display());
+                }
             }
         }
     }
@@ -717,12 +729,17 @@ pub(crate) fn load_all_overlay_targets(
         let path = entry.path();
         if path.extension().is_some_and(|e| e == "ccl") {
             let content = fs::read_to_string(&path)?;
-            if let Ok(state) = sickle::from_str::<OverlayState>(&content) {
-                for file in &state.files {
-                    targets.insert(
-                        file.target.to_string_lossy().to_string(),
-                        state.name.clone(),
-                    );
+            match sickle::from_str::<OverlayState>(&content) {
+                Ok(state) => {
+                    for file in &state.files {
+                        targets.insert(
+                            file.target.to_string_lossy().to_string(),
+                            state.name.clone(),
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to parse state file {}: {e}", path.display());
                 }
             }
         }

--- a/src/widgets/multi_select_tree.rs
+++ b/src/widgets/multi_select_tree.rs
@@ -35,7 +35,7 @@ pub(crate) struct TreeNode<'a, Id> {
     /// Display text for this node.
     pub(crate) text: Line<'a>,
     /// Child nodes.
-    pub(crate) children: Vec<TreeNode<'a, Id>>,
+    pub(crate) children: Vec<Self>,
 }
 
 /// State for a multi-select tree widget.


### PR DESCRIPTION
## Summary

- Replace `if let Ok(...)` patterns with `match` statements in three `state.rs` functions (`remove_external_state`, `load_external_states`, `load_all_overlay_targets`) so that CCL parse errors are logged via `log::warn!` instead of being silently dropped
- Add `warn` to the existing `log` import
- Fix a pre-existing clippy `use_self` lint in `multi_select_tree.rs`

Closes #236

## Test plan

- [x] All 155 existing tests pass
- [x] Clippy passes with pedantic + nursery lints
- [x] `cargo fmt` check passes