### PR TITLE
feat: add `move` command for relocating overlays

### DIFF
--- a/.changes/unreleased/move-Added-20260413-120000.yaml
+++ b/.changes/unreleased/move-Added-20260413-120000.yaml
@@ -1,0 +1,11 @@
+component: move
+kind: Added
+body: |-
+    `repoverlay move` command for relocating overlays
+
+    Adds a new top-level `move` command that relocates an overlay's source files between locations while preserving applied state. Supports moving to the in-repo library (`--to library`), to a filesystem path (`--to /path/to/dir`), or renaming on move (`--name`).
+
+    The operation is interrupt-safe: files are copied to the destination, state is updated, symlinks are re-created pointing to the new location, then the source is deleted. If interrupted, the worst case is a duplicate that can be cleaned up manually.
+
+    Supports `--force` to overwrite existing destinations and `--dry-run` to preview changes.
+time: 2026-04-13T12:00:00.000000-07:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -44,6 +44,7 @@ components:
     - create-local
     - edit
     - list
+    - move
     - remove
     - restore
     - source

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod cache;
 pub(crate) mod create;
 pub(crate) mod edit;
 pub(crate) mod library;
+pub(crate) mod r#move;
 pub(crate) mod source;
 pub(crate) mod sync;
 

--- a/src/cli/commands/move.rs
+++ b/src/cli/commands/move.rs
@@ -234,6 +234,7 @@ fn parse_destination(to: &str, target: &Path, dest_name: &str) -> Result<Destina
         let dest = library_path.join(dest_name);
         Ok(Destination::Library { path: dest })
     } else if let Some(source_name) = to.strip_prefix("source:") {
+        // TODO(#273): support moving to named sources
         bail!(
             "Moving to named source '{source_name}' is not yet implemented. \
              Use a filesystem path instead."

--- a/src/cli/commands/move.rs
+++ b/src/cli/commands/move.rs
@@ -1,0 +1,274 @@
+use anyhow::{Context, Result, bail};
+use colored::Colorize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::library;
+use crate::overlay_repo::copy_dir_recursive;
+use crate::state::{
+    EntryType, LinkType, OverlaySource, load_overlay_state, normalize_overlay_name,
+    save_external_state, save_overlay_state,
+};
+
+use super::resolve_target;
+
+/// Handle the `move` command.
+pub(crate) fn handle_move_command(
+    overlay: &str,
+    to: &str,
+    target: &Path,
+    force: bool,
+    name_override: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    let target = resolve_target(Some(target.to_path_buf()))?;
+    let normalized_name = normalize_overlay_name(overlay)?;
+
+    // Load current overlay state
+    let mut state = load_overlay_state(&target, &normalized_name)?;
+
+    // Resolve current source path
+    let current_source_path = resolve_source_path(&target, &state.source)?;
+
+    // Determine destination name
+    let dest_name = name_override.unwrap_or(overlay);
+
+    // Parse and resolve destination
+    let destination = parse_destination(to, &target, dest_name)?;
+
+    // Check for circular move (same location)
+    if let Destination::Library { ref path } = destination {
+        if let OverlaySource::Library { .. } = &state.source
+            && name_override.is_none()
+        {
+            eprintln!(
+                "{} Overlay '{}' is already in the library — nothing to do.",
+                "Warning:".yellow(),
+                overlay
+            );
+            return Ok(());
+        }
+        // Also check if the source path IS the destination
+        if current_source_path.exists()
+            && path.exists()
+            && paths_equivalent(&current_source_path, path)
+        {
+            eprintln!(
+                "{} Source and destination are the same — nothing to do.",
+                "Warning:".yellow(),
+            );
+            return Ok(());
+        }
+    }
+
+    let dest_path = destination.path();
+
+    if dry_run {
+        println!("{} Dry run — would move overlay:", "Note:".yellow());
+        println!("  From: {}", current_source_path.display());
+        println!("  To:   {}", dest_path.display());
+        return Ok(());
+    }
+
+    // Check for conflicts at destination
+    if dest_path.exists() {
+        if force {
+            fs::remove_dir_all(dest_path).with_context(|| {
+                format!(
+                    "Failed to remove existing destination: {}",
+                    dest_path.display()
+                )
+            })?;
+        } else {
+            bail!(
+                "Destination already exists: {}. Use --force to overwrite or --name to rename.",
+                dest_path.display()
+            );
+        }
+    }
+
+    println!(
+        "{} overlay '{}' to {}",
+        "Moving".green().bold(),
+        overlay,
+        destination.display_label()
+    );
+
+    // Step 1: Copy to destination
+    fs::create_dir_all(dest_path)
+        .with_context(|| format!("Failed to create destination: {}", dest_path.display()))?;
+    copy_dir_recursive(&current_source_path, dest_path)
+        .with_context(|| format!("Failed to copy overlay to: {}", dest_path.display()))?;
+
+    // Step 2: Update state source reference
+    let new_source = destination.to_overlay_source(dest_name);
+    state.source = new_source;
+
+    save_overlay_state(&target, &state)?;
+    // Best-effort external state update
+    if let Err(e) = save_external_state(&target, &normalized_name, &state) {
+        eprintln!(
+            "  {} Could not update external backup: {}",
+            "Warning:".yellow(),
+            e
+        );
+    }
+
+    // Step 3: Re-create symlinks pointing to new location
+    let mut relinked = 0;
+    for entry in state.file_entries() {
+        if entry.link_type != LinkType::Symlink {
+            continue;
+        }
+
+        let symlink_path = target.join(&entry.target);
+        if !symlink_path.is_symlink() {
+            continue;
+        }
+
+        let new_link_target = dest_path.join(&entry.source);
+
+        // Remove old symlink
+        #[cfg(unix)]
+        {
+            fs::remove_file(&symlink_path).with_context(|| {
+                format!("Failed to remove old symlink: {}", symlink_path.display())
+            })?;
+        }
+        #[cfg(windows)]
+        {
+            if entry.entry_type == EntryType::Directory {
+                fs::remove_dir(&symlink_path).with_context(|| {
+                    format!("Failed to remove old symlink: {}", symlink_path.display())
+                })?;
+            } else {
+                fs::remove_file(&symlink_path).with_context(|| {
+                    format!("Failed to remove old symlink: {}", symlink_path.display())
+                })?;
+            }
+        }
+
+        // Create new symlink
+        match entry.entry_type {
+            EntryType::File => {
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(&new_link_target, &symlink_path).with_context(|| {
+                    format!("Failed to create symlink: {}", symlink_path.display())
+                })?;
+                #[cfg(windows)]
+                std::os::windows::fs::symlink_file(&new_link_target, &symlink_path).with_context(
+                    || format!("Failed to create symlink: {}", symlink_path.display()),
+                )?;
+            }
+            EntryType::Directory => {
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(&new_link_target, &symlink_path).with_context(|| {
+                    format!("Failed to create symlink: {}", symlink_path.display())
+                })?;
+                #[cfg(windows)]
+                std::os::windows::fs::symlink_dir(&new_link_target, &symlink_path).with_context(
+                    || format!("Failed to create symlink: {}", symlink_path.display()),
+                )?;
+            }
+        }
+
+        relinked += 1;
+    }
+
+    // Step 4: Delete from source location
+    if current_source_path.exists() {
+        fs::remove_dir_all(&current_source_path).with_context(|| {
+            format!(
+                "Failed to remove old source: {}",
+                current_source_path.display()
+            )
+        })?;
+    }
+
+    println!(
+        "\n{} Moved '{}' to {}",
+        "✓".green().bold(),
+        overlay,
+        dest_path.display()
+    );
+
+    if relinked > 0 {
+        println!("  Re-linked {relinked} symlink(s)");
+    }
+
+    Ok(())
+}
+
+/// Parsed destination for a move operation.
+enum Destination {
+    Library { path: PathBuf },
+    Path { path: PathBuf },
+}
+
+impl Destination {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Library { path } | Self::Path { path } => path,
+        }
+    }
+
+    fn display_label(&self) -> String {
+        match self {
+            Self::Library { path } => format!("library ({})", path.display()),
+            Self::Path { path } => path.display().to_string(),
+        }
+    }
+
+    fn to_overlay_source(&self, name: &str) -> OverlaySource {
+        match self {
+            Self::Library { .. } => OverlaySource::library(name.to_string()),
+            Self::Path { path } => OverlaySource::local(path.clone()),
+        }
+    }
+}
+
+/// Parse the `--to` argument into a resolved destination.
+fn parse_destination(to: &str, target: &Path, dest_name: &str) -> Result<Destination> {
+    if to == "library" {
+        let library_path = library::get_library_path(target)?;
+        let dest = library_path.join(dest_name);
+        Ok(Destination::Library { path: dest })
+    } else if let Some(source_name) = to.strip_prefix("source:") {
+        bail!(
+            "Moving to named source '{source_name}' is not yet implemented. \
+             Use a filesystem path instead."
+        );
+    } else {
+        let base = PathBuf::from(to);
+        let dest = base.join(dest_name);
+        Ok(Destination::Path { path: dest })
+    }
+}
+
+/// Resolve the filesystem path for the current overlay source.
+fn resolve_source_path(target: &Path, source: &OverlaySource) -> Result<PathBuf> {
+    match source {
+        OverlaySource::Library { name } => {
+            let library_path = library::get_library_path(target)?;
+            Ok(library_path.join(name))
+        }
+        OverlaySource::Local { path } => Ok(path.clone()),
+        OverlaySource::GitHub { .. } => {
+            bail!("Cannot move a GitHub-sourced overlay. Import it to the library first.")
+        }
+        OverlaySource::OverlayRepo { .. } => {
+            bail!(
+                "Cannot move an overlay-repo-sourced overlay directly. \
+                 Import it to the library first."
+            )
+        }
+    }
+}
+
+/// Check if two paths point to the same location.
+fn paths_equivalent(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,6 +246,40 @@ enum Commands {
         force: bool,
     },
 
+    /// Move an overlay to a new location
+    ///
+    /// Relocates an overlay's source files and updates applied state references.
+    /// Destinations: "library", "source:<name>", or a filesystem path.
+    ///
+    /// Examples:
+    ///   repoverlay move my-overlay --to library
+    ///   repoverlay move my-overlay --to /path/to/dir
+    ///   repoverlay move my-overlay --to source:shared-repo
+    Move {
+        /// Name of the applied overlay to move
+        overlay: String,
+
+        /// Destination: "library", "source:<name>", or a filesystem path
+        #[arg(long)]
+        to: String,
+
+        /// Target repository directory (defaults to current directory)
+        #[arg(short, long)]
+        target: Option<PathBuf>,
+
+        /// Overwrite if destination already exists
+        #[arg(long)]
+        force: bool,
+
+        /// Rename the overlay at the destination
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Show what would happen without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Switch to a different overlay (removes all existing overlays first)
     Switch {
         /// Path to overlay source directory OR GitHub URL
@@ -777,6 +811,24 @@ pub(crate) fn run() -> Result<()> {
             } else {
                 create_overlay_command(&source, name, output, &include, dry_run, yes, force)?;
             }
+        }
+        Commands::Move {
+            overlay,
+            to,
+            target,
+            force,
+            name,
+            dry_run,
+        } => {
+            let target = target.unwrap_or_else(|| PathBuf::from("."));
+            commands::r#move::handle_move_command(
+                &overlay,
+                &to,
+                &target,
+                force,
+                name.as_deref(),
+                dry_run,
+            )?;
         }
         Commands::Switch {
             source,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4050,3 +4050,479 @@ fn extends_diamond_dependency_is_not_a_cycle() {
     assert!(ctx.file_exists("y.txt"), "branch-y file");
     assert!(ctx.file_exists("child.txt"), "child's own file");
 }
+
+// ── Move command tests ──────────────────────────────────────────────────────
+
+#[test]
+fn move_help_displays() {
+    cargo_bin_cmd!("repoverlay")
+        .args(["move", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Move"));
+}
+
+#[test]
+fn move_to_library() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay (symlink mode — the default on unix)
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "test-move",
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert!(ctx.is_symlink(".envrc"));
+    assert!(ctx.overlay_state_exists("test-move"));
+
+    // Move to library
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "test-move",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // State should still exist and reference library source
+    assert!(ctx.overlay_state_exists("test-move"));
+    let state_content =
+        fs::read_to_string(ctx.repo_path().join(".repoverlay/overlays/test-move.ccl"))
+            .expect("state file should exist");
+    assert!(
+        state_content.contains("Library"),
+        "state source should be Library, got: {state_content}"
+    );
+
+    // Symlink should still work (now pointing to library)
+    assert!(ctx.file_exists(".envrc"));
+    assert!(ctx.is_symlink(".envrc"));
+
+    // Library should contain the overlay
+    assert!(
+        ctx.repo_path()
+            .join(".repoverlay/library/test-move/.envrc")
+            .exists()
+    );
+
+    // Original source should still exist (it's the test temp dir, not managed by us)
+    // but the old source path in state should be replaced
+}
+
+#[test]
+fn move_to_filesystem_path() {
+    let ctx = TestContext::new();
+
+    // Create a library overlay and apply it
+    create_library_overlay(&ctx, "lib-overlay", &[(".envrc", "export LIB=true")]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "lib-overlay",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert!(ctx.overlay_state_exists("lib-overlay"));
+
+    // Move to a filesystem path
+    let dest = tempfile::TempDir::new().unwrap();
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "lib-overlay",
+            "--to",
+            dest.path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // State should reference Local source now
+    let state_content =
+        fs::read_to_string(ctx.repo_path().join(".repoverlay/overlays/lib-overlay.ccl"))
+            .expect("state file should exist");
+    assert!(
+        state_content.contains("Local"),
+        "state source should be Local, got: {state_content}"
+    );
+
+    // Overlay files should exist at destination
+    assert!(dest.path().join("lib-overlay/.envrc").exists());
+
+    // Library entry should be removed
+    assert!(
+        !ctx.repo_path()
+            .join(".repoverlay/library/lib-overlay")
+            .exists(),
+        "library entry should be removed after move"
+    );
+}
+
+#[test]
+fn move_preserves_copy_entries() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply with --copy
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "copied",
+            "--copy",
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert!(!ctx.is_symlink(".envrc"), "should be a copy, not symlink");
+
+    let content_before = ctx.read_file(".envrc");
+
+    // Move to library
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "copied",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Copied file should be unchanged (not re-linked)
+    assert!(ctx.file_exists(".envrc"));
+    assert!(
+        !ctx.is_symlink(".envrc"),
+        "copy entry should remain a copy after move"
+    );
+    assert_eq!(ctx.read_file(".envrc"), content_before);
+
+    // State should now reference library
+    let state_content = fs::read_to_string(ctx.repo_path().join(".repoverlay/overlays/copied.ccl"))
+        .expect("state file should exist");
+    assert!(
+        state_content.contains("Library"),
+        "state source should be Library"
+    );
+}
+
+#[test]
+fn move_name_conflict_errors() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "conflict-test",
+        ])
+        .assert()
+        .success();
+
+    // Pre-create a library overlay with same name
+    create_library_overlay(&ctx, "conflict-test", &[("other.txt", "existing")]);
+
+    // Move should fail due to name conflict
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "conflict-test",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn move_force_overwrites() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "force-test",
+        ])
+        .assert()
+        .success();
+
+    // Pre-create a library overlay with same name
+    create_library_overlay(&ctx, "force-test", &[("other.txt", "existing")]);
+
+    // Move with --force should succeed
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "force-test",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    // Library should have the moved overlay's content, not the old one
+    assert!(
+        ctx.repo_path()
+            .join(".repoverlay/library/force-test/.envrc")
+            .exists()
+    );
+    assert!(
+        !ctx.repo_path()
+            .join(".repoverlay/library/force-test/other.txt")
+            .exists(),
+        "old library content should be replaced"
+    );
+}
+
+#[test]
+fn move_with_rename() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "original-name",
+        ])
+        .assert()
+        .success();
+
+    // Move to library with a new name
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "original-name",
+            "--to",
+            "library",
+            "--name",
+            "renamed",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Library should have the new name
+    assert!(
+        ctx.repo_path()
+            .join(".repoverlay/library/renamed/.envrc")
+            .exists()
+    );
+    assert!(
+        !ctx.repo_path()
+            .join(".repoverlay/library/original-name")
+            .exists(),
+        "old name should not exist in library"
+    );
+}
+
+#[test]
+fn move_dry_run() {
+    let ctx = TestContext::new().with_overlay(&envrc_overlay());
+
+    // Apply overlay
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "dry-run-test",
+        ])
+        .assert()
+        .success();
+
+    // Read state before
+    let state_before = fs::read_to_string(
+        ctx.repo_path()
+            .join(".repoverlay/overlays/dry-run-test.ccl"),
+    )
+    .expect("state file should exist");
+
+    // Move with --dry-run
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "dry-run-test",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+
+    // Nothing should have changed
+    let state_after = fs::read_to_string(
+        ctx.repo_path()
+            .join(".repoverlay/overlays/dry-run-test.ccl"),
+    )
+    .expect("state file should still exist");
+    assert_eq!(
+        state_before, state_after,
+        "state should not change on dry run"
+    );
+
+    // Library should not have been created
+    assert!(
+        !ctx.repo_path()
+            .join(".repoverlay/library/dry-run-test")
+            .exists(),
+        "library entry should not exist after dry run"
+    );
+}
+
+#[test]
+fn move_circular_noop() {
+    let ctx = TestContext::new();
+
+    // Create a library overlay and apply it
+    create_library_overlay(&ctx, "circular-test", &[(".envrc", "export C=true")]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "circular-test",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Move from library to library should warn
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "circular-test",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("already"));
+}
+
+#[test]
+fn move_nonexistent_overlay_errors() {
+    let ctx = TestContext::new();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "nonexistent",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn move_symlinks_recreated_pointing_to_new_location() {
+    let ctx = TestContext::new().with_overlay(&[
+        (".envrc", "export FOO=bar"),
+        (".editorconfig", "root = true"),
+    ]);
+
+    // Apply with symlinks
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            ctx.overlay_source(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "relink-test",
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.is_symlink(".envrc"));
+    assert!(ctx.is_symlink(".editorconfig"));
+
+    // Read symlink targets before move
+    let old_envrc_target = fs::read_link(ctx.repo_path().join(".envrc")).unwrap();
+
+    // Move to library
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "relink-test",
+            "--to",
+            "library",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Symlinks should still be symlinks
+    assert!(ctx.is_symlink(".envrc"));
+    assert!(ctx.is_symlink(".editorconfig"));
+
+    // Symlinks should now point to the library location
+    let new_envrc_target = fs::read_link(ctx.repo_path().join(".envrc")).unwrap();
+    assert_ne!(
+        old_envrc_target, new_envrc_target,
+        "symlink target should change after move"
+    );
+    assert!(
+        new_envrc_target
+            .to_string_lossy()
+            .contains(".repoverlay/library"),
+        "symlink should point to library: {}",
+        new_envrc_target.display()
+    );
+
+    // Files should still be readable through the symlinks
+    assert_eq!(ctx.read_file(".envrc"), "export FOO=bar");
+    assert_eq!(ctx.read_file(".editorconfig"), "root = true");
+}


### PR DESCRIPTION
## Summary

- Add `repoverlay move <overlay> --to <destination>` command that relocates an overlay's source files between locations while preserving applied state and symlinks
- Supports `--to library`, `--to <path>`, `--force`, `--name`, and `--dry-run`
- `source:<name>` destination recognized but not yet implemented (tracked in #273)
- Interrupt-safe ordering: copy → update state → re-link symlinks → delete source

## Test plan

- [x] 10 new integration tests covering: move to library, move to path, copy preservation, name conflicts, force overwrite, rename, dry run, circular no-op, nonexistent overlay error, symlink re-creation verification
- [x] All 1318 existing tests still pass
- [x] `just check` passes (format, clippy, build, test)

Closes #216