### PR TITLE
fix: resolve library path relative to target repo in `create --into library`

### DIFF
--- a/.changes/unreleased/create-Fixed-20260413-150000.yaml
+++ b/.changes/unreleased/create-Fixed-20260413-150000.yaml
@@ -1,0 +1,7 @@
+component: create
+kind: Fixed
+body: |-
+    `create --into library` resolves library path relative to target repo instead of source
+
+    Previously, `create --into library --source <path>` placed the overlay into the source repo's library instead of the target repo's (cwd). Added `--target` parameter to the `create` command for explicit target specification, consistent with other commands like `move` and `switch`.
+time: 2026-04-13T15:00:00.000000000-07:00

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -92,9 +92,10 @@ pub(crate) fn parse_overlay_name_arg(
 /// Create an overlay directly into the in-repo library.
 ///
 /// After creation, prompts to apply the overlay (unless `--yes` or `--no-apply`).
-#[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub(crate) fn create_into_library(
     source: &Path,
+    target: &Path,
     name: Option<String>,
     include: &[PathBuf],
     dry_run: bool,
@@ -110,8 +111,17 @@ pub(crate) fn create_into_library(
         );
     }
 
+    // Validate target is a git repo
+    if !target.join(".git").exists() {
+        bail!(
+            "Target directory is not a git repository: {}",
+            target.display()
+        );
+    }
+
     let source = canonicalize_path(source, "Source")?;
-    let library_path = library::get_library_path(&source)?;
+    let target = canonicalize_path(target, "Target")?;
+    let library_path = library::get_library_path(&target)?;
 
     // Determine overlay name
     let overlay_name = name.unwrap_or_else(|| "overlay".to_string());
@@ -123,12 +133,12 @@ pub(crate) fn create_into_library(
     }
 
     // Auto-fix gitignore if library path is ignored
-    if library::ensure_library_not_gitignored(&source, &library_path)? {
+    if library::ensure_library_not_gitignored(&target, &library_path)? {
         eprintln!(
             "{} Updated .gitignore to track library path {}",
             "Note:".cyan().bold(),
             library_path
-                .strip_prefix(&source)
+                .strip_prefix(&target)
                 .unwrap_or(&library_path)
                 .display()
         );
@@ -179,7 +189,7 @@ pub(crate) fn create_into_library(
             let overlay_source = output_path.to_string_lossy().to_string();
             crate::apply_overlay(
                 &overlay_source,
-                &source,
+                &target,
                 false,
                 Some(overlay_name),
                 None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -221,6 +221,10 @@ enum Commands {
         #[arg(short, long)]
         source: Option<PathBuf>,
 
+        /// Target repository directory (defaults to current directory)
+        #[arg(short, long)]
+        target: Option<PathBuf>,
+
         /// Output directory for local overlay creation (no overlay repo required)
         #[arg(short, long, conflicts_with = "into")]
         output: Option<PathBuf>,
@@ -796,6 +800,7 @@ pub(crate) fn run() -> Result<()> {
             name,
             include,
             source,
+            target,
             output,
             into,
             no_apply,
@@ -805,7 +810,10 @@ pub(crate) fn run() -> Result<()> {
         } => {
             let source = source.unwrap_or_else(|| PathBuf::from("."));
             if into.as_deref() == Some("library") {
-                create_into_library(&source, name, &include, dry_run, yes, no_apply, force)?;
+                let target = target.unwrap_or_else(|| PathBuf::from("."));
+                create_into_library(
+                    &source, &target, name, &include, dry_run, yes, no_apply, force,
+                )?;
             } else if let Some(dest) = &into {
                 bail!("Unknown --into destination: {dest}. Valid values: library");
             } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2907,6 +2907,8 @@ fn create_into_library_with_include() {
             "CLAUDE.md",
             "--source",
             ctx.repo_path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
             "--no-apply",
             "-y",
         ])
@@ -2938,6 +2940,8 @@ fn create_into_library_with_name() {
             ".envrc",
             "--source",
             ctx.repo_path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
             "--no-apply",
             "-y",
         ])
@@ -2966,6 +2970,8 @@ fn create_into_library_applies_by_default_with_yes() {
             "--include",
             ".envrc",
             "--source",
+            ctx.repo_path().to_str().unwrap(),
+            "--target",
             ctx.repo_path().to_str().unwrap(),
             "-y",
         ])
@@ -3012,6 +3018,103 @@ fn create_into_library_no_apply_requires_into() {
         .args(["create", "--no-apply", "-y"])
         .assert()
         .failure();
+}
+
+// --- create --into library resolves to target, not source (#275) ---
+
+#[test]
+fn create_into_library_uses_target_not_source() {
+    // Source repo: has files to extract
+    let source_ctx = TestContext::new();
+    source_ctx.create_repo_file(".envrc", "use flake");
+
+    // Target repo: where the library overlay should land
+    let target_ctx = TestContext::new();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "create",
+            "--into",
+            "library",
+            "--include",
+            ".envrc",
+            "--source",
+            source_ctx.repo_path().to_str().unwrap(),
+            "--target",
+            target_ctx.repo_path().to_str().unwrap(),
+            "--no-apply",
+            "-y",
+        ])
+        .assert()
+        .success();
+
+    // Overlay must be in the TARGET repo's library
+    let target_library = target_ctx
+        .repo_path()
+        .join(".repoverlay")
+        .join("library")
+        .join("overlay");
+    assert!(
+        target_library.join(".envrc").exists(),
+        "Overlay should be in target repo's library, but was not found at {}",
+        target_library.display()
+    );
+
+    // Overlay must NOT be in the source repo's library
+    let source_library = source_ctx
+        .repo_path()
+        .join(".repoverlay")
+        .join("library")
+        .join("overlay");
+    assert!(
+        !source_library.exists(),
+        "Overlay should NOT be in source repo's library, but was found at {}",
+        source_library.display()
+    );
+}
+
+#[test]
+fn create_into_library_applies_to_target_repo() {
+    // Source repo: has files to extract
+    let source_ctx = TestContext::new();
+    source_ctx.create_repo_file(".envrc", "use flake");
+
+    // Target repo: where overlay should be applied
+    let target_ctx = TestContext::new();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "create",
+            "my-overlay",
+            "--into",
+            "library",
+            "--include",
+            ".envrc",
+            "--source",
+            source_ctx.repo_path().to_str().unwrap(),
+            "--target",
+            target_ctx.repo_path().to_str().unwrap(),
+            "-y",
+        ])
+        .assert()
+        .success();
+
+    // Overlay should be applied in the target repo
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "status",
+            "--target",
+            target_ctx.repo_path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("my-overlay"));
+
+    // Target repo should have the overlay file
+    assert!(
+        target_ctx.file_exists(".envrc"),
+        "Overlay file should be applied in target repo"
+    );
 }
 
 // --- library import by name (#220) ---


### PR DESCRIPTION
## Summary

- `create --into library --source <path>` placed the overlay into the **source** repo's `.repoverlay/library/` instead of the **target** repo's (cwd)
- Added `--target` parameter to `create` command (consistent with `move`, `switch`, etc.) and wired it through to library path resolution, gitignore fixup, and overlay application
- Updated existing tests to explicitly pass `--target` and added two new tests that verify source != target behavior

## Test plan

- [x] New test `create_into_library_uses_target_not_source` — verifies overlay lands in target, not source
- [x] New test `create_into_library_applies_to_target_repo` — verifies apply targets the right repo  
- [x] All 177 existing tests pass
- [x] `just check` (format + lint + test) passes clean

Closes #275