### PR TITLE
fix: resolve three-part references using repo-local sources

### DIFF
--- a/.changes/unreleased/apply-Fixed-20260413-223227.yaml
+++ b/.changes/unreleased/apply-Fixed-20260413-223227.yaml
@@ -1,0 +1,7 @@
+component: apply
+kind: Fixed
+body: |-
+    Match GitHub URLs against repo-local sources for overlay repo upgrade
+
+    When applying via a GitHub URL that matches a configured source, repoverlay upgrades to editable overlay repo mode. This matching now includes repo-local sources, not just global ones.
+time: 2026-04-13T22:32:27.000000000+00:00

--- a/.changes/unreleased/fixes-Fixed-20260413-223226.yaml
+++ b/.changes/unreleased/fixes-Fixed-20260413-223226.yaml
@@ -1,0 +1,7 @@
+component: fixes
+kind: Fixed
+body: |-
+    Resolve three-part overlay references using repo-local sources
+
+    `resolve_three_part()` and `find_matching_source()` loaded only global config, ignoring sources configured at the repo level via `repoverlay source add`. Three-part references like `org/repo/overlay` and GitHub URL matching now correctly merge repo-local sources from `.repoverlay/config.ccl`.
+time: 2026-04-13T22:32:26.000000000+00:00

--- a/.changes/unreleased/fixes-Fixed-20260413-223226.yaml
+++ b/.changes/unreleased/fixes-Fixed-20260413-223226.yaml
@@ -1,7 +1,7 @@
-component: fixes
+component: apply
 kind: Fixed
 body: |-
     Resolve three-part overlay references using repo-local sources
 
-    `resolve_three_part()` and `find_matching_source()` loaded only global config, ignoring sources configured at the repo level via `repoverlay source add`. Three-part references like `org/repo/overlay` and GitHub URL matching now correctly merge repo-local sources from `.repoverlay/config.ccl`.
+    Three-part references like `org/repo/overlay` failed with "Overlay repository not configured" when the source was configured at the repo level via `repoverlay source add`. Repo-local sources in `.repoverlay/config.ccl` are now correctly loaded during resolution.
 time: 2026-04-13T22:32:26.000000000+00:00

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -61,8 +61,12 @@ pub(crate) enum ResolvedSources {
 ///
 /// Loads the user config and checks each source URL against the provided
 /// owner and repo. Returns the first matching source, if any.
-fn find_matching_source(owner: &str, repo: &str) -> Option<config::Source> {
-    let config = config::load_config(None).ok()?;
+fn find_matching_source(
+    owner: &str,
+    repo: &str,
+    target_path: Option<&Path>,
+) -> Option<config::Source> {
+    let config = config::load_config(target_path).ok()?;
     config.sources.into_iter().find(|source| {
         source
             .url
@@ -106,7 +110,7 @@ pub(crate) fn try_upgrade_github_source(target: &Path, state: &mut OverlayState)
         parts[2].to_string(),
     );
 
-    let Some(source) = find_matching_source(&owner, &gh_repo) else {
+    let Some(source) = find_matching_source(&owner, &gh_repo, Some(target)) else {
         return Ok(false);
     };
 
@@ -200,7 +204,7 @@ pub(crate) fn resolve_source(
             // as an overlay repo (editable) instead of a read-only GitHub source.
             if let Ok(github_source) = GitHubSource::parse(&url)
                 && let Some(matched) =
-                    find_matching_source(&github_source.owner, &github_source.repo)
+                    find_matching_source(&github_source.owner, &github_source.repo, target_path)
             {
                 // Check if the URL includes a subpath that looks like org/repo/name
                 if let Some(ref subpath) = github_source.subpath {
@@ -768,8 +772,8 @@ fn resolve_three_part(
 ) -> Result<ResolvedSource> {
     debug!("resolving three-part reference: {org}/{repo}/{name}");
 
-    // Load config
-    let config = config::load_config(None)?;
+    // Load config (pass target_path to include repo-local sources)
+    let config = config::load_config(target_path)?;
 
     // Detect upstream for fallback resolution
     let upstream = target_path.and_then(|p| detect_upstream(p).ok()).flatten();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4629,3 +4629,68 @@ fn move_symlinks_recreated_pointing_to_new_location() {
     assert_eq!(ctx.read_file(".envrc"), "export FOO=bar");
     assert_eq!(ctx.read_file(".editorconfig"), "root = true");
 }
+
+// ============================================================================
+// Three-Part Resolution with Repo-Local Sources (issue #276)
+// ============================================================================
+
+#[test]
+fn apply_three_part_resolves_repo_local_source() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    // Create a local overlays directory with org/repo/overlay structure
+    let overlay_dir = ctx.repo_path().join("my-overlays/acme/widgets/my-overlay");
+    fs::create_dir_all(&overlay_dir).expect("Failed to create overlay dir");
+    fs::write(overlay_dir.join(".envrc"), "export FOO=bar").unwrap();
+
+    // Add as repo-local source
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./my-overlays", "--name", "local-src"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Apply using three-part reference — this should resolve via the repo-local source
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", "acme/widgets/my-overlay"])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applying"));
+
+    assert!(ctx.file_exists(".envrc"));
+    assert_eq!(ctx.read_file(".envrc"), "export FOO=bar");
+}
+
+#[test]
+fn apply_three_part_with_source_filter_resolves_repo_local_source() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    // Create a local overlays directory with org/repo/overlay structure
+    let overlay_dir = ctx.repo_path().join("my-overlays/acme/widgets/my-overlay");
+    fs::create_dir_all(&overlay_dir).expect("Failed to create overlay dir");
+    fs::write(overlay_dir.join(".editorconfig"), "root = true").unwrap();
+
+    // Add as repo-local source
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./my-overlays", "--name", "team-src"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Apply using --from to target the repo-local source by name
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", "acme/widgets/my-overlay", "--from", "team-src"])
+        .args(["--target", ctx.repo_path().to_str().unwrap()])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".editorconfig"));
+    assert_eq!(ctx.read_file(".editorconfig"), "root = true");
+}


### PR DESCRIPTION
## Summary

- **`resolve_three_part()`** and **`find_matching_source()`** called `load_config(None)`, loading only global config and ignoring repo-level sources configured via `repoverlay source add`
- Pass `target_path` through to `load_config()` so that sources in `.repoverlay/config.ccl` are merged when resolving three-part overlay references (`org/repo/overlay`) and matching GitHub URLs to configured sources

Closes #276

Related: filed #279 for the same class of bug in `prompt_save_source()` (lower priority — only affects duplicate-check for save prompt).

## Test plan

- [x] Added `apply_three_part_resolves_repo_local_source` — verifies three-part apply works with repo-local source
- [x] Added `apply_three_part_with_source_filter_resolves_repo_local_source` — verifies `--from` filter works with repo-local source
- [x] Both tests confirmed failing before the fix ("Overlay repository not configured")
- [x] Full suite passes: 179 tests, clippy clean, format clean
