### PR TITLE
fix: add missing git remote in sync TC-06 manual test

### DIFF
--- a/.changes/unreleased/sync-Fixed-20260413-160014.yaml
+++ b/.changes/unreleased/sync-Fixed-20260413-160014.yaml
@@ -1,0 +1,7 @@
+component: sync
+kind: Fixed
+body: |-
+    Add missing git remote setup in TC-06 manual test for library overlay sync rejection
+
+    The `sync.md` TC-06 test case was missing a `git remote add origin` step for the `target-library-repo`. Without it, `sync` failed with "Could not detect target repository from git remote" instead of reaching the library-rejection logic being tested. Also added automated tests covering library source rejection for both `sync --all` and single-name paths.
+time: 2026-04-13T16:00:14.307780000-07:00

--- a/.changes/unreleased/sync-Fixed-20260413-160014.yaml
+++ b/.changes/unreleased/sync-Fixed-20260413-160014.yaml
@@ -1,7 +1,0 @@
-component: sync
-kind: Fixed
-body: |-
-    Add missing git remote setup in TC-06 manual test for library overlay sync rejection
-
-    The `sync.md` TC-06 test case was missing a `git remote add origin` step for the `target-library-repo`. Without it, `sync` failed with "Could not detect target repository from git remote" instead of reaching the library-rejection logic being tested. Also added automated tests covering library source rejection for both `sync --all` and single-name paths.
-time: 2026-04-13T16:00:14.307780000-07:00

--- a/docs/manual-tests/sync.md
+++ b/docs/manual-tests/sync.md
@@ -172,6 +172,7 @@ cd "$TEST_DIR"
 
 mkdir target-library-repo && cd target-library-repo
 git init
+git remote add origin https://github.com/example/library-repo.git
 git commit --allow-empty -m "init"
 cd "$TEST_DIR"
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4271,6 +4271,26 @@ directories =
             );
         }
 
+        /// Issue #277: `sync --all` must skip library-source overlays without
+        /// trying to load an overlay-repo config.
+        #[test]
+        fn handle_sync_all_skips_library_sources() {
+            let repo = create_test_repo();
+
+            save_test_state(
+                repo.path(),
+                "library-overlay",
+                OverlaySource::library("library-overlay".to_string()),
+                vec![(".envrc", ".envrc")],
+            );
+
+            let result = handle_sync(repo.path(), None, true, false);
+            assert!(
+                result.is_ok(),
+                "sync --all should succeed when only library overlays are applied: {result:?}"
+            );
+        }
+
         #[test]
         fn handle_sync_all_identifies_overlay_repo_sources() {
             let repo = create_test_repo();
@@ -6269,6 +6289,50 @@ directories =
             assert!(
                 msg.contains("GitHub") && (msg.contains("sync") || msg.contains("syncable")),
                 "sync error for GitHub source should mention the source type. Got: {msg}"
+            );
+        }
+
+        /// Issue #277: `handle_sync` for a single name with a library source
+        /// should fail with a clear error about library sources not being
+        /// syncable (not a confusing "Could not detect target repository" error).
+        #[test]
+        fn issue_277_sync_single_rejects_library_source() {
+            let repo = create_test_repo();
+
+            // Set up a git remote so parse_overlay_name_arg can detect org/repo
+            std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/testorg/testrepo.git",
+                ])
+                .current_dir(repo.path())
+                .output()
+                .unwrap();
+
+            // Create a library-sourced overlay
+            save_test_state(
+                repo.path(),
+                "library-overlay",
+                OverlaySource::library("library-overlay".to_string()),
+                vec![(".envrc", ".envrc")],
+            );
+
+            let result = handle_sync(
+                repo.path(),
+                Some("library-overlay".to_string()),
+                false, // not --all
+                false,
+            );
+
+            // Should fail because library sources aren't syncable
+            assert!(result.is_err(), "sync should fail for library sources");
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("library") && (msg.contains("sync") || msg.contains("syncable")),
+                "Bug #277: sync error for library source should mention the source type \
+                 and syncability. Got: {msg}"
             );
         }
 


### PR DESCRIPTION
## Summary

- Adds missing `git remote add origin` to TC-06 setup in `docs/manual-tests/sync.md` so `sync` reaches the library-rejection logic instead of failing on remote detection
- Adds automated test `handle_sync_all_skips_library_sources` covering `sync --all` with library-sourced overlays
- Adds automated test `issue_277_sync_single_rejects_library_source` covering single-name sync rejection of library sources

Closes #277

## Test plan

- [x] `just check` passes (format, clippy, all unit + integration tests)
- [x] New test `handle_sync_all_skips_library_sources` verifies `--all` path skips library overlays
- [x] New test `issue_277_sync_single_rejects_library_source` verifies single-name path rejects library sources with correct error message