### PR TITLE
feat(browse): make browse the primary recommended interactive workflow

### DIFF
--- a/.changes/unreleased/browse-Changed-20260516-021827.yaml
+++ b/.changes/unreleased/browse-Changed-20260516-021827.yaml
@@ -1,0 +1,13 @@
+component: browse
+kind: Changed
+body: |-
+    `browse` is now the documented primary workflow for interactive overlay application
+
+    - `browse` help text and command list clarify it is the recommended interactive path
+    - `apply` help text updated to describe it as the scripting/power-user command,
+      with explicit guidance to use `browse` for interactive discovery
+    - Non-interactive `browse` output now directs users to run browse in a terminal
+      instead of suggesting the `apply org/repo/name` syntax
+    - A tip is printed to stderr when `apply` is used with the `org/repo/name`
+      configured-source syntax, encouraging `browse` for interactive workflows
+time: 2026-05-16T02:18:40.000000000+00:00

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,6 +11,7 @@ This document contains the help content for the `repoverlay` command-line progra
 * [`repoverlay restore`↴](#repoverlay-restore)
 * [`repoverlay update`↴](#repoverlay-update)
 * [`repoverlay create`↴](#repoverlay-create)
+* [`repoverlay move`↴](#repoverlay-move)
 * [`repoverlay switch`↴](#repoverlay-switch)
 * [`repoverlay cache`↴](#repoverlay-cache)
 * [`repoverlay cache list`↴](#repoverlay-cache-list)
@@ -25,6 +26,11 @@ This document contains the help content for the `repoverlay` command-line progra
 * [`repoverlay source add`↴](#repoverlay-source-add)
 * [`repoverlay source list`↴](#repoverlay-source-list)
 * [`repoverlay source remove`↴](#repoverlay-source-remove)
+* [`repoverlay library`↴](#repoverlay-library)
+* [`repoverlay library list`↴](#repoverlay-library-list)
+* [`repoverlay library import`↴](#repoverlay-library-import)
+* [`repoverlay library export`↴](#repoverlay-library-export)
+* [`repoverlay library remove`↴](#repoverlay-library-remove)
 * [`repoverlay completions`↴](#repoverlay-completions)
 
 ## `repoverlay`
@@ -35,35 +41,39 @@ Overlay config files into git repositories without committing them
 
 ###### **Subcommands:**
 
-* `apply` — Apply an overlay to a git repository
+* `apply` — Apply an overlay to a git repository (scripting / power-user)
 * `remove` — Remove applied overlay(s)
 * `status` — Show the status of applied overlays
 * `restore` — Restore overlays after git clean or other removal
 * `update` — Update applied overlays from remote sources
 * `create` — Create a new overlay from files in a repository
+* `move` — Move an overlay to a new location
 * `switch` — Switch to a different overlay (removes all existing overlays first)
 * `cache` — Manage the overlay cache
 * `browse` — Browse and apply overlays interactively (recommended)
 * `sync` — Sync changes from an applied overlay back to the overlay repo
 * `edit` — Edit an existing applied overlay
 * `source` — Manage overlay sources (for multi-source configurations)
+* `library` — Manage the in-repo overlay library
 * `completions` — Generate shell completions
 
 
 
 ## `repoverlay apply`
 
-Apply an overlay to a git repository
+Apply an overlay to a git repository (scripting / power-user)
 
-For interactive use, consider `repoverlay browse` instead.
+Applies an overlay directly from a path, GitHub URL, or configured source. Intended for scripting and automation workflows.
+
+For interactive discovery and application, use `repoverlay browse` instead — it lists available overlays and lets you select which to apply.
 
 **Usage:** `repoverlay apply [OPTIONS] <SOURCE>`
 
 ###### **Arguments:**
 
-* `<SOURCE>` — Path to overlay source directory OR GitHub URL
+* `<SOURCE>` — Overlay source: local path, GitHub URL, or configured source reference
 
-   Examples: ./my-overlay <https://github.com/owner/repo> <https://github.com/owner/repo/tree/main/overlays/rust>
+   Supported formats: ./my-overlay             (local path) /absolute/path           (local absolute path) <https://github.com/owner/repo> <https://github.com/owner/repo/tree/main/overlays/rust> org/repo/overlay-name    (configured source reference)
 
 ###### **Options:**
 
@@ -171,10 +181,37 @@ Examples: repoverlay create my-overlay              # Detects org/repo from git 
 
 * `-i`, `--include <INCLUDE>` — Include files/directories or glob patterns (can be specified multiple times)
 * `-s`, `--source <SOURCE>` — Source repository to extract files from (defaults to current directory)
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 * `-o`, `--output <OUTPUT>` — Output directory for local overlay creation (no overlay repo required)
+* `--into <DEST>` — Create the overlay directly into a destination ("library")
+* `--no-apply` — Skip applying the overlay after creating into the library
 * `--dry-run` — Show what would be created without creating files
 * `-y`, `--yes` — Skip interactive prompts, use defaults
 * `-f`, `--force` — Force overwrite if overlay already exists
+
+
+
+## `repoverlay move`
+
+Move an overlay to a new location
+
+Relocates an overlay's source files and updates applied state references. Destinations: "library", "source:<name>", or a filesystem path.
+
+Examples: repoverlay move my-overlay --to library repoverlay move my-overlay --to /path/to/dir repoverlay move my-overlay --to source:shared-repo
+
+**Usage:** `repoverlay move [OPTIONS] --to <TO> <OVERLAY>`
+
+###### **Arguments:**
+
+* `<OVERLAY>` — Name of the applied overlay to move
+
+###### **Options:**
+
+* `--to <TO>` — Destination: "library", "source:<name>", or a filesystem path
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
+* `--force` — Overwrite if destination already exists
+* `--name <NAME>` — Rename the overlay at the destination
+* `--dry-run` — Show what would happen without making changes
 
 
 
@@ -417,6 +454,85 @@ Remove an overlay source
 ###### **Arguments:**
 
 * `<NAME>` — Name of the source to remove
+
+
+
+## `repoverlay library`
+
+Manage the in-repo overlay library
+
+**Usage:** `repoverlay library <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List overlays in the library
+* `import` — Import an overlay into the library
+* `export` — Export an overlay from the library
+* `remove` — Remove an overlay from the library
+
+
+
+## `repoverlay library list`
+
+List overlays in the library
+
+**Usage:** `repoverlay library list [OPTIONS]`
+
+###### **Options:**
+
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
+
+
+
+## `repoverlay library import`
+
+Import an overlay into the library
+
+**Usage:** `repoverlay library import [OPTIONS] <SOURCE>`
+
+###### **Arguments:**
+
+* `<SOURCE>` — Overlay source (path, GitHub URL, or org/repo/name)
+
+###### **Options:**
+
+* `--name <NAME>` — Name for the imported overlay (defaults to source name)
+* `-f`, `--force` — Force overwrite if overlay already exists
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
+
+
+
+## `repoverlay library export`
+
+Export an overlay from the library
+
+**Usage:** `repoverlay library export [OPTIONS] --to <DEST> <OVERLAY>`
+
+###### **Arguments:**
+
+* `<OVERLAY>` — Name of the overlay to export
+
+###### **Options:**
+
+* `--to <DEST>` — Destination path
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
+
+
+
+## `repoverlay library remove`
+
+Remove an overlay from the library
+
+**Usage:** `repoverlay library remove [OPTIONS] <OVERLAY>`
+
+###### **Arguments:**
+
+* `<OVERLAY>` — Name of the overlay to remove
+
+###### **Options:**
+
+* `-f`, `--force` — Force removal even if overlay is currently applied
+* `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 
 
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -397,7 +397,13 @@ impl CacheManager {
             return Ok(None);
         }
 
-        let current_commit = self.get_current_commit(&repo_path)?;
+        let current_commit = match self.get_current_commit(&repo_path) {
+            Ok(commit) => commit,
+            Err(err) => {
+                warn!("could not determine current commit for cached repo: {err}");
+                return Ok(None);
+            }
+        };
 
         // Fetch latest
         let output = git_in_dir(&repo_path, &["fetch", "--depth", "1", "origin"])?;

--- a/src/cli/commands/browse.rs
+++ b/src/cli/commands/browse.rs
@@ -95,8 +95,8 @@ fn print_overlay_list(overlays: &[AvailableOverlay], filtered: bool) {
     }
 
     println!(
-        "\nTo apply an overlay: repoverlay apply {}",
-        "<org>/<repo>/<name>".dimmed()
+        "\n{}",
+        "Run `repoverlay browse` in an interactive terminal to select and apply overlays.".dimmed()
     );
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@ use colored::Colorize;
 use std::io::{self};
 use std::path::PathBuf;
 
+use crate::reference::SourceReference;
 use crate::{
     ConflictStrategy, apply_overlay, config, repair_git_exclude, restore_overlays, show_status,
     show_status_json, status_has_overlays, switch_overlay,
@@ -44,16 +45,22 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Apply an overlay to a git repository
+    /// Apply an overlay to a git repository (scripting / power-user)
     ///
-    /// For interactive use, consider `repoverlay browse` instead.
+    /// Applies an overlay directly from a path, GitHub URL, or configured source.
+    /// Intended for scripting and automation workflows.
+    ///
+    /// For interactive discovery and application, use `repoverlay browse` instead —
+    /// it lists available overlays and lets you select which to apply.
     Apply {
-        /// Path to overlay source directory OR GitHub URL
+        /// Overlay source: local path, GitHub URL, or configured source reference
         ///
-        /// Examples:
-        ///   ./my-overlay
+        /// Supported formats:
+        ///   ./my-overlay             (local path)
+        ///   /absolute/path           (local absolute path)
         ///   <https://github.com/owner/repo>
         ///   <https://github.com/owner/repo/tree/main/overlays/rust>
+        ///   org/repo/overlay-name    (configured source reference)
         source: String,
 
         /// Target repository directory (defaults to current directory)
@@ -721,6 +728,17 @@ pub(crate) fn run() -> Result<()> {
         } => {
             let target = target.unwrap_or_else(|| PathBuf::from("."));
             let conflict_strategy = conflict_strategy(force, skip_conflicts, interactive);
+            // Nudge users toward `browse` when using the three-part configured-source syntax
+            // interactively; `apply` remains fully supported for scripting.
+            if matches!(
+                SourceReference::parse(&source),
+                SourceReference::ThreePart { .. }
+            ) {
+                eprintln!(
+                    "{} `repoverlay browse` is the recommended way to interactively discover and apply overlays.",
+                    "tip:".cyan().bold(),
+                );
+            }
             apply_overlay(
                 &source,
                 &target,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,7 +8,7 @@ use predicates::prelude::*;
 use std::fs;
 
 mod common;
-use common::{SourceTestContext, TestContext, envrc_overlay};
+use common::{SourceTestContext, TestContext, create_overlay_dir, envrc_overlay};
 
 #[test]
 fn help_displays() {
@@ -930,7 +930,52 @@ fn switch_help_shows_options() {
         .args(["switch", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Switch"));
+        .stdout(predicate::str::contains("Switch"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+#[test]
+fn switch_dry_run_previews_without_changing_overlays() {
+    let ctx = TestContext::new();
+    let overlay_a = create_overlay_dir(&[(".config-a", "alpha")]);
+    let overlay_b = create_overlay_dir(&[(".config-b", "beta")]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            overlay_a.path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "overlay-a",
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".config-a"));
+    assert!(!ctx.file_exists(".config-b"));
+    assert!(ctx.overlay_state_exists("overlay-a"));
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "switch",
+            overlay_b.path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "overlay-b",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dry run"))
+        .stdout(predicate::str::contains("would remove"))
+        .stdout(predicate::str::contains("Would apply"));
+
+    assert!(ctx.file_exists(".config-a"));
+    assert!(!ctx.file_exists(".config-b"));
+    assert!(ctx.overlay_state_exists("overlay-a"));
+    assert!(!ctx.overlay_state_exists("overlay-b"));
 }
 
 // ============================================================================

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,7 +34,8 @@ fn apply_help_displays() {
         .args(["apply", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Apply an overlay"));
+        .stdout(predicate::str::contains("Apply an overlay"))
+        .stdout(predicate::str::contains("repoverlay browse"));
 }
 
 #[test]
@@ -119,6 +120,36 @@ fn browse_rejects_three_part_source() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Invalid source for browse"));
+}
+
+#[test]
+fn apply_help_mentions_browse_for_interactive() {
+    // apply help text should guide interactive users toward browse
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("repoverlay browse"));
+}
+
+#[test]
+fn apply_help_mentions_scripting() {
+    // apply help text should clarify it is the scripting / power-user path
+    cargo_bin_cmd!("repoverlay")
+        .args(["apply", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("scripting"));
+}
+
+#[test]
+fn root_help_browse_listed_as_recommended() {
+    // top-level help should list browse as "recommended"
+    cargo_bin_cmd!("repoverlay")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("recommended"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Makes `browse` the documented primary workflow for interactive overlay application, as proposed in #184.

## Changes

- **`apply` command description** updated to clarify it is the scripting/power-user path, with explicit guidance to use `browse` for interactive discovery
- **`apply` source argument docs** updated to list all supported formats (local path, GitHub URL, `org/repo/name`)
- **Three-part syntax tip**: when `apply` is used with `org/repo/name` configured-source syntax, a `tip:` hint is printed to stderr suggesting `browse`
- **Non-interactive `browse` output** now directs users to run browse in an interactive terminal instead of the old "apply org/repo/name" suggestion
- **`docs/cli-reference.md`** regenerated to reflect updated help text
- **Changelog entry** added

## Testing

- Updated `apply_help_displays` test to verify help text references `repoverlay browse`
- Added `apply_help_mentions_browse_for_interactive` — verifies apply help guides users to browse
- Added `apply_help_mentions_scripting` — verifies apply help clarifies scripting use case
- Added `root_help_browse_listed_as_recommended` — verifies top-level help lists browse as recommended

All existing tests pass. Pre-commit hooks (cargo-fmt + cargo-clippy) clean.

## Non-goals (per issue)

- `apply` with direct paths unchanged and fully supported
- No CLI surface removed — pure UX/docs shift

Fixes #184