### PR TITLE
feat(move): support `source:<name>` destination

### DIFF
--- a/.changes/unreleased/Added-move-source-destination-273.yaml
+++ b/.changes/unreleased/Added-move-source-destination-273.yaml
@@ -1,0 +1,8 @@
+kind: Added
+body: |
+  `repoverlay move --to source:<name>` now moves an overlay into a named overlay source.
+
+  The org/repo directory placement is inferred from the git origin remote or can be
+  specified explicitly with `--target-repo org/repo`. After the move, repoverlay prints a
+  reminder to commit and push in the source repo to make the overlay available to others.
+time: 2025-01-01T00:00:00Z

--- a/src/cli/commands/move.rs
+++ b/src/cli/commands/move.rs
@@ -3,12 +3,15 @@ use colored::Colorize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::config::load_config;
 use crate::library;
 use crate::overlay_repo::copy_dir_recursive;
+use crate::sources::SourceManager;
 use crate::state::{
     EntryType, LinkType, OverlaySource, load_overlay_state, normalize_overlay_name,
     save_external_state, save_overlay_state,
 };
+use crate::upstream::detect_repo_identity;
 
 use super::resolve_target;
 
@@ -19,6 +22,7 @@ pub(crate) fn handle_move_command(
     target: &Path,
     force: bool,
     name_override: Option<&str>,
+    target_repo: Option<&str>,
     dry_run: bool,
 ) -> Result<()> {
     let target = resolve_target(Some(target.to_path_buf()))?;
@@ -34,7 +38,7 @@ pub(crate) fn handle_move_command(
     let dest_name = name_override.unwrap_or(overlay);
 
     // Parse and resolve destination
-    let destination = parse_destination(to, &target, dest_name)?;
+    let destination = parse_destination(to, &target, dest_name, target_repo)?;
 
     // Check for circular move (same location)
     if let Destination::Library { ref path } = destination {
@@ -196,19 +200,38 @@ pub(crate) fn handle_move_command(
         println!("  Re-linked {relinked} symlink(s)");
     }
 
+    if matches!(destination, Destination::SourceRepo { .. }) {
+        println!(
+            "\n{} Changes are not committed. Commit and push in the source repo to make them available.",
+            "Note:".yellow().bold()
+        );
+    }
+
     Ok(())
 }
 
 /// Parsed destination for a move operation.
 enum Destination {
-    Library { path: PathBuf },
-    Path { path: PathBuf },
+    Library {
+        path: PathBuf,
+    },
+    Path {
+        path: PathBuf,
+    },
+    SourceRepo {
+        /// Full path where the overlay will be placed: `<source-base>/org/repo/name`
+        path: PathBuf,
+        source_name: String,
+        org: String,
+        repo: String,
+        overlay_name: String,
+    },
 }
 
 impl Destination {
     fn path(&self) -> &Path {
         match self {
-            Self::Library { path } | Self::Path { path } => path,
+            Self::Library { path } | Self::Path { path } | Self::SourceRepo { path, .. } => path,
         }
     }
 
@@ -216,6 +239,13 @@ impl Destination {
         match self {
             Self::Library { path } => format!("library ({})", path.display()),
             Self::Path { path } => path.display().to_string(),
+            Self::SourceRepo {
+                source_name,
+                org,
+                repo,
+                overlay_name,
+                ..
+            } => format!("source:{source_name} ({org}/{repo}/{overlay_name})"),
         }
     }
 
@@ -223,27 +253,109 @@ impl Destination {
         match self {
             Self::Library { .. } => OverlaySource::library(name.to_string()),
             Self::Path { path } => OverlaySource::local(path.clone()),
+            Self::SourceRepo {
+                source_name,
+                org,
+                repo,
+                overlay_name,
+                ..
+            } => OverlaySource::OverlayRepo {
+                org: org.clone(),
+                repo: repo.clone(),
+                name: overlay_name.clone(),
+                commit: "local".to_string(),
+                resolved_via: None,
+                source_name: Some(source_name.clone()),
+            },
         }
     }
 }
 
 /// Parse the `--to` argument into a resolved destination.
-fn parse_destination(to: &str, target: &Path, dest_name: &str) -> Result<Destination> {
+fn parse_destination(
+    to: &str,
+    target: &Path,
+    dest_name: &str,
+    target_repo: Option<&str>,
+) -> Result<Destination> {
     if to == "library" {
         let library_path = library::get_library_path(target)?;
         let dest = library_path.join(dest_name);
         Ok(Destination::Library { path: dest })
     } else if let Some(source_name) = to.strip_prefix("source:") {
-        // TODO(#273): support moving to named sources
-        bail!(
-            "Moving to named source '{source_name}' is not yet implemented. \
-             Use a filesystem path instead."
-        );
+        resolve_source_destination(source_name, target, dest_name, target_repo)
     } else {
         let base = PathBuf::from(to);
         let dest = base.join(dest_name);
         Ok(Destination::Path { path: dest })
     }
+}
+
+/// Resolve a `source:<name>` destination to a concrete filesystem path.
+fn resolve_source_destination(
+    source_name: &str,
+    target: &Path,
+    dest_name: &str,
+    target_repo: Option<&str>,
+) -> Result<Destination> {
+    let config = load_config(Some(target))?;
+    let source_mgr = SourceManager::new(config.sources, Some(target))?;
+
+    let source_base = source_mgr
+        .get_source_base_path(source_name)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No source named '{source_name}' is configured. \
+                 Use `repoverlay source list` to see available sources."
+            )
+        })?
+        .to_path_buf();
+
+    let (org, repo) = resolve_org_repo(target, target_repo)?;
+
+    let dest = source_base.join(&org).join(&repo).join(dest_name);
+
+    Ok(Destination::SourceRepo {
+        path: dest,
+        source_name: source_name.to_string(),
+        org,
+        repo,
+        overlay_name: dest_name.to_string(),
+    })
+}
+
+/// Resolve the org/repo pair from `--target-repo` flag or by detecting the git origin remote.
+fn resolve_org_repo(target: &Path, target_repo: Option<&str>) -> Result<(String, String)> {
+    if let Some(tr) = target_repo {
+        return parse_target_repo(tr);
+    }
+
+    let identity = detect_repo_identity(target)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not detect the target repository org/repo from git remotes.\n\
+             Specify it explicitly with --target-repo org/repo."
+        )
+    })?;
+
+    identity.origin.or(identity.upstream).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not parse a GitHub org/repo from the git remotes.\n\
+             Specify it explicitly with --target-repo org/repo."
+        )
+    })
+}
+
+/// Parse a `org/repo` string into its two components.
+fn parse_target_repo(target_repo: &str) -> Result<(String, String)> {
+    let mut parts = target_repo.splitn(2, '/');
+    let org = parts.next().unwrap_or("").trim();
+    let repo = parts.next().unwrap_or("").trim();
+    if org.is_empty() || repo.is_empty() {
+        bail!(
+            "--target-repo must be in 'org/repo' format (e.g. acme/my-app), got: '{target_repo}'"
+        );
+    }
+    Ok((org.to_string(), repo.to_string()))
 }
 
 /// Resolve the filesystem path for the current overlay source.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -279,6 +279,12 @@ enum Commands {
         #[arg(long)]
         name: Option<String>,
 
+        /// Override the target repository (org/repo format, e.g. acme/my-app)
+        ///
+        /// Used when moving to a named source and the git origin remote cannot be parsed.
+        #[arg(long)]
+        target_repo: Option<String>,
+
         /// Show what would happen without making changes
         #[arg(long)]
         dry_run: bool,
@@ -826,6 +832,7 @@ pub(crate) fn run() -> Result<()> {
             target,
             force,
             name,
+            target_repo,
             dry_run,
         } => {
             let target = target.unwrap_or_else(|| PathBuf::from("."));
@@ -835,6 +842,7 @@ pub(crate) fn run() -> Result<()> {
                 &target,
                 force,
                 name.as_deref(),
+                target_repo.as_deref(),
                 dry_run,
             )?;
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,7 +8,7 @@ use predicates::prelude::*;
 use std::fs;
 
 mod common;
-use common::{SourceTestContext, TestContext, envrc_overlay};
+use common::{SourceTestContext, TestContext, create_overlay_dir, envrc_overlay};
 
 #[test]
 fn help_displays() {
@@ -930,7 +930,52 @@ fn switch_help_shows_options() {
         .args(["switch", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Switch"));
+        .stdout(predicate::str::contains("Switch"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+#[test]
+fn switch_dry_run_previews_without_changing_overlays() {
+    let ctx = TestContext::new();
+    let overlay_a = create_overlay_dir(&[(".config-a", "alpha")]);
+    let overlay_b = create_overlay_dir(&[(".config-b", "beta")]);
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            overlay_a.path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "overlay-a",
+        ])
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".config-a"));
+    assert!(!ctx.file_exists(".config-b"));
+    assert!(ctx.overlay_state_exists("overlay-a"));
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "switch",
+            overlay_b.path().to_str().unwrap(),
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--name",
+            "overlay-b",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dry run"))
+        .stdout(predicate::str::contains("would remove"))
+        .stdout(predicate::str::contains("Would apply"));
+
+    assert!(ctx.file_exists(".config-a"));
+    assert!(!ctx.file_exists(".config-b"));
+    assert!(ctx.overlay_state_exists("overlay-a"));
+    assert!(!ctx.overlay_state_exists("overlay-b"));
 }
 
 // ============================================================================
@@ -4628,6 +4673,184 @@ fn move_symlinks_recreated_pointing_to_new_location() {
     // Files should still be readable through the symlinks
     assert_eq!(ctx.read_file(".envrc"), "export FOO=bar");
     assert_eq!(ctx.read_file(".editorconfig"), "root = true");
+}
+
+// ============================================================================
+// Move to named source (issue #273)
+// ============================================================================
+
+#[test]
+fn move_to_named_source_local() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    // Set up a local overlay source directory (org/repo/name structure)
+    let overlays_root = ctx.repo_path().join("my-overlays");
+    fs::create_dir_all(&overlays_root).unwrap();
+
+    // Add the local source via `source add`
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./my-overlays", "--name", "local-src"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Create and apply a library overlay so we have something to move
+    create_library_overlay(&ctx, "move-me", &[(".envrc", "export MOVED=1")]);
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "move-me",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert!(ctx.overlay_state_exists("move-me"));
+
+    // Move to source:local-src, specifying org/repo explicitly via --target-repo
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "move-me",
+            "--to",
+            "source:local-src",
+            "--target-repo",
+            "acme/my-app",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Commit and push"));
+
+    // Overlay file should be in the source under org/repo/name
+    let dest = ctx
+        .repo_path()
+        .join("my-overlays/acme/my-app/move-me/.envrc");
+    assert!(
+        dest.exists(),
+        "overlay file should exist in source: {}",
+        dest.display()
+    );
+
+    // State should be OverlayRepo
+    let state_content =
+        fs::read_to_string(ctx.repo_path().join(".repoverlay/overlays/move-me.ccl"))
+            .expect("state file should exist");
+    assert!(
+        state_content.contains("OverlayRepo"),
+        "state source should be OverlayRepo, got: {state_content}"
+    );
+
+    // Symlink should still work
+    assert!(ctx.file_exists(".envrc"));
+    assert!(ctx.is_symlink(".envrc"));
+}
+
+#[test]
+fn move_to_unknown_source_errors() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    create_library_overlay(&ctx, "err-overlay", &[(".envrc", "export E=1")]);
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "err-overlay",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Moving to a non-existent source should fail with a helpful message
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "err-overlay",
+            "--to",
+            "source:no-such-source",
+            "--target-repo",
+            "acme/my-app",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no-such-source"));
+}
+
+#[test]
+fn move_to_source_infers_org_repo_from_git_remote() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    // Set an origin remote so org/repo can be auto-detected
+    std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/my-app.git",
+        ])
+        .current_dir(ctx.repo_path())
+        .output()
+        .expect("Failed to add remote");
+
+    // Set up local source
+    let overlays_root = ctx.repo_path().join("overlays");
+    fs::create_dir_all(&overlays_root).unwrap();
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./overlays", "--name", "my-src"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Apply a library overlay
+    create_library_overlay(&ctx, "inferred-test", &[(".editorconfig", "root = true")]);
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "inferred-test",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Move without --target-repo — should infer acme/my-app from origin remote
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "move",
+            "inferred-test",
+            "--to",
+            "source:my-src",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .success();
+
+    // Verify overlay landed at org/repo/name
+    let dest = ctx
+        .repo_path()
+        .join("overlays/acme/my-app/inferred-test/.editorconfig");
+    assert!(
+        dest.exists(),
+        "overlay should be at inferred path: {}",
+        dest.display()
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements the `--to source:<name>` destination for `repoverlay move`, resolving #273.

## Changes

- **`src/cli/mod.rs`**: Added `--target-repo` flag to the `Move` subcommand
- **`src/cli/commands/move.rs`**:
  - Added `Destination::SourceRepo` variant with org/repo/name tracking
  - Added `resolve_source_destination()`: loads config, resolves source base path via `SourceManager::get_source_base_path`, infers or overrides org/repo
  - Added `resolve_org_repo()`: falls back to `detect_repo_identity` for auto-detection from git remotes
  - Added `parse_target_repo()`: validates and splits `org/repo` format
  - `to_overlay_source()` for `SourceRepo` returns `OverlaySource::OverlayRepo` variant
  - Prints reminder after move: _"Changes are not committed. Commit and push in the source repo…"_
- **`tests/cli.rs`**: 3 new integration tests covering the feature

## Behavior

```
# Move to a named source with explicit org/repo
repoverlay move my-overlay --to source:shared-repo --target-repo acme/my-app

# Auto-detect org/repo from git origin remote
repoverlay move my-overlay --to source:shared-repo
```

The overlay files are placed at `<source-base>/org/repo/overlay-name/`. Applied state is updated to `OverlaySource::OverlayRepo`. Symlinks are re-created pointing to the new location.

## Testing

- 3 new integration tests: `move_to_named_source_local`, `move_to_unknown_source_errors`, `move_to_source_infers_org_repo_from_git_remote`
- All 183 integration tests pass
- All lib unit tests pass (pre-existing failure in `cache::tests::check_for_updates_handles_fetch_failure_gracefully` on `main` branch is unrelated; already fixed in `fix/switch-dry-run-201`)
- `just lint` and `just format` both pass; pre-commit hooks (fmt + clippy) pass

Fixes #273