### PR TITLE
chore: upgrade CI actions

### DIFF
--- a/.changes/unreleased/Changed-20260516-094534.yaml
+++ b/.changes/unreleased/Changed-20260516-094534.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Publish a maintenance release without application code changes
+
+    This release refreshes project release metadata only. There are no changes to repoverlay behavior, commands, or generated binaries.
+time: 2026-05-16T09:45:34.105-07:00

--- a/.github/workflows/changie-release.yml
+++ b/.github/workflows/changie-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: tylerbutler/actions/changie-release@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/changie-release@main
+      - uses: tylerbutler/actions/changie-release@1629403295067f43d639169be094e55b8a2b839d # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install tools
-        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # ratchet:taiki-e/install-action@v2
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # ratchet:taiki-e/install-action@v2
         with:
           tool: just,cargo-llvm-cov
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: tylerbutler/actions/changie-check@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/changie-check@main
+      - uses: tylerbutler/actions/changie-check@1629403295067f43d639169be094e55b8a2b839d # ratchet:tylerbutler/actions/changie-check@main
         id: changelog
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ !fromJson(inputs.plan).announcement_is_prerelease || fromJson(inputs.plan).publish_prereleases }}
     steps:
-      - uses: tylerbutler/actions/publish-homebrew-formula@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/publish-homebrew-formula@main
+      - uses: tylerbutler/actions/publish-homebrew-formula@1629403295067f43d639169be094e55b8a2b839d # ratchet:tylerbutler/actions/publish-homebrew-formula@main
         with:
           # Reuses the shared release App (see release-plz.yml, changie-release.yml).
           # The App must be installed on tylerbutler/homebrew-tap with contents:write.

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # ratchet:actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Upgrade CI workflow actions to newer pinned revisions.
- Add a user-facing changie entry to force a maintenance publish.

## Release note

This release refreshes project release metadata only. There are no changes to repoverlay behavior, commands, or generated binaries.

## Testing

- `changie batch --dry-run auto`
