### PR TITLE
fix: harden flat local sources

### DIFF
--- a/.changes/unreleased/Fixed-20260524-030542.yaml
+++ b/.changes/unreleased/Fixed-20260524-030542.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    Fix local flat source detection
+
+    Local directory sources now auto-detect flat overlay folders, including dotfile-only overlays.
+time: 2026-05-24T03:05:42.128536524Z

--- a/src/cli/commands/browse.rs
+++ b/src/cli/commands/browse.rs
@@ -72,7 +72,7 @@ fn print_overlay_list(overlays: &[AvailableOverlay], filtered: bool) {
             if current_group.is_some() {
                 println!();
             }
-            if overlay.flat {
+            if overlay.is_flat() {
                 println!("{}:", "(flat)".dimmed());
             } else {
                 println!("{}{}{}:", overlay.org.cyan(), "/".dimmed(), overlay.repo);
@@ -205,14 +205,12 @@ pub(crate) fn browse_overlays(
     // Add library overlays to the browse list (#218)
     if has_library && target_filter.is_none() {
         for lib_overlay in &library_overlays {
-            overlays.push(AvailableOverlay {
-                org: library::LIBRARY_SOURCE_NAME.to_string(),
-                repo: String::new(),
-                name: lib_overlay.name.clone(),
-                has_config: true,
-                flat: true,
-                relative_path: lib_overlay.name.clone().into(),
-            });
+            overlays.push(AvailableOverlay::synthetic_flat(
+                library::LIBRARY_SOURCE_NAME.to_string(),
+                lib_overlay.name.clone(),
+                lib_overlay.name.clone().into(),
+                true,
+            ));
         }
     }
 
@@ -242,12 +240,13 @@ pub(crate) fn browse_overlays(
             .ok_or_else(|| anyhow::anyhow!("Source base path not found: {}", source.name))?;
         let commit = mgr.get_source_commit(&source.name)?;
 
-        Ok(resolve_configured_browse_source(
+        resolve_configured_browse_source(
             base_path,
             o,
             commit,
             source.name.clone(),
-        ))
+            source.is_local(),
+        )
     };
 
     browse_and_apply(
@@ -277,22 +276,20 @@ fn browse_ephemeral_source(
 ) -> Result<()> {
     let reference = SourceReference::parse(source_str);
 
-    // Handle local paths directly
-    if let SourceReference::LocalPath { path, .. } = &reference {
-        let canonical = path
-            .canonicalize()
-            .with_context(|| format!("Path does not exist: {}", path.display()))?;
-        return browse_local_source(
-            &canonical,
-            target_filter,
-            target,
-            no_interactive,
-            dry_run,
-            show_all,
-        );
-    }
-
     let (owner, repo) = match reference {
+        SourceReference::LocalPath { path, .. } => {
+            let canonical = path
+                .canonicalize()
+                .with_context(|| format!("Path does not exist: {}", path.display()))?;
+            return browse_local_source(
+                &canonical,
+                target_filter,
+                target,
+                no_interactive,
+                dry_run,
+                show_all,
+            );
+        }
         SourceReference::OnePart { username } => {
             let default_repo = config::default_overlay_repo_name();
             (username, default_repo)
@@ -308,7 +305,6 @@ fn browse_ephemeral_source(
                  Use a GitHub username, owner/repo, GitHub URL, or local path."
             );
         }
-        SourceReference::LocalPath { .. } => unreachable!(),
     };
 
     let github_url = format!("https://github.com/{owner}/{repo}");
@@ -409,14 +405,37 @@ fn browse_local_source(
 }
 
 fn resolve_local_browse_source(local_base: &Path, o: &AvailableOverlay) -> Result<ResolvedSource> {
-    let overlay_path = local_base.join(o.relative_path());
-    if !overlay_path.exists() {
-        bail!("Overlay directory not found: {}", overlay_path.display());
-    }
+    let overlay_path = resolve_browse_overlay_path(local_base, o)?;
     Ok(ResolvedSource {
         path: overlay_path.clone(),
         source_info: OverlaySource::local(overlay_path),
     })
+}
+
+fn resolve_browse_overlay_path(base: &Path, o: &AvailableOverlay) -> Result<PathBuf> {
+    let overlay_path = base.join(o.source_relative_path());
+    let canonical_base = base
+        .canonicalize()
+        .with_context(|| format!("Source base not found: {}", base.display()))?;
+    let canonical_overlay = overlay_path
+        .canonicalize()
+        .with_context(|| format!("Overlay directory not found: {}", overlay_path.display()))?;
+
+    if !canonical_overlay.starts_with(&canonical_base) {
+        bail!(
+            "Overlay directory escapes source base: {}",
+            overlay_path.display()
+        );
+    }
+
+    if !canonical_overlay.is_dir() {
+        bail!(
+            "Overlay path is not a directory: {}",
+            overlay_path.display()
+        );
+    }
+
+    Ok(canonical_overlay)
 }
 
 fn resolve_configured_browse_source(
@@ -424,25 +443,28 @@ fn resolve_configured_browse_source(
     o: &AvailableOverlay,
     commit: impl Into<String>,
     source_name: impl Into<String>,
-) -> ResolvedSource {
-    let overlay_path = base_path.join(o.relative_path());
-    let source_info = if o.flat {
-        OverlaySource::local(overlay_path.clone())
+    source_is_local: bool,
+) -> Result<ResolvedSource> {
+    let overlay_path = resolve_browse_overlay_path(base_path, o)?;
+    let commit = commit.into();
+    let source_name = source_name.into();
+    let source_info = if source_is_local {
+        OverlaySource::configured_local(overlay_path.clone(), source_name)
     } else {
         OverlaySource::overlay_repo_full(
             o.org.clone(),
             o.repo.clone(),
             o.name.clone(),
-            commit.into(),
+            commit,
             ResolvedVia::Direct,
-            source_name.into(),
+            source_name,
         )
     };
 
-    ResolvedSource {
+    Ok(ResolvedSource {
         path: overlay_path,
         source_info,
-    }
+    })
 }
 
 /// Shared logic for browse: filter, display, select, and apply overlays.
@@ -541,25 +563,16 @@ mod tests {
     use super::*;
 
     fn flat_overlay(name: &str, relative_path: &str) -> AvailableOverlay {
-        AvailableOverlay {
-            org: String::new(),
-            repo: String::new(),
-            name: name.to_string(),
-            has_config: false,
-            flat: true,
-            relative_path: PathBuf::from(relative_path),
-        }
+        AvailableOverlay::flat(name.to_string(), PathBuf::from(relative_path), false)
     }
 
     fn structured_overlay() -> AvailableOverlay {
-        AvailableOverlay {
-            org: "owner".to_string(),
-            repo: "repo".to_string(),
-            name: "config".to_string(),
-            has_config: false,
-            flat: false,
-            relative_path: PathBuf::from("owner/repo/config"),
-        }
+        AvailableOverlay::structured(
+            "owner".to_string(),
+            "repo".to_string(),
+            "config".to_string(),
+            false,
+        )
     }
 
     #[test]
@@ -572,9 +585,27 @@ mod tests {
 
         assert_eq!(resolved.path, source.path().join("config-a"));
         match resolved.source_info {
-            OverlaySource::Local { path } => assert_eq!(path, source.path().join("config-a")),
+            OverlaySource::Local { path, .. } => assert_eq!(path, source.path().join("config-a")),
             other => panic!("expected local source, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_browse_rejects_symlink_overlay_that_escapes_source_base() {
+        use std::os::unix::fs::symlink;
+
+        let source = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        fs::write(outside.path().join(".envrc"), "export SECRET=1").unwrap();
+        symlink(outside.path(), source.path().join("escape")).unwrap();
+        let overlay = flat_overlay("escape", "escape");
+
+        let Err(err) = resolve_local_browse_source(source.path(), &overlay) else {
+            panic!("expected symlink escape to be rejected");
+        };
+
+        assert!(err.to_string().contains("escapes source base"));
     }
 
     #[test]
@@ -584,11 +615,15 @@ mod tests {
         let overlay = flat_overlay("config-a", "config-a");
 
         let resolved =
-            resolve_configured_browse_source(source.path(), &overlay, "local", "local-flat");
+            resolve_configured_browse_source(source.path(), &overlay, "local", "local-flat", true)
+                .unwrap();
 
         assert_eq!(resolved.path, source.path().join("config-a"));
         match resolved.source_info {
-            OverlaySource::Local { path } => assert_eq!(path, source.path().join("config-a")),
+            OverlaySource::Local { path, source_name } => {
+                assert_eq!(path, source.path().join("config-a"));
+                assert_eq!(source_name.as_deref(), Some("local-flat"));
+            }
             other => panic!("expected local source, got {other:?}"),
         }
     }
@@ -600,7 +635,8 @@ mod tests {
         let overlay = structured_overlay();
 
         let resolved =
-            resolve_configured_browse_source(source.path(), &overlay, "abc123", "shared");
+            resolve_configured_browse_source(source.path(), &overlay, "abc123", "shared", false)
+                .unwrap();
 
         assert_eq!(resolved.path, source.path().join("owner/repo/config"));
         match resolved.source_info {

--- a/src/cli/commands/browse.rs
+++ b/src/cli/commands/browse.rs
@@ -211,6 +211,7 @@ pub(crate) fn browse_overlays(
                 name: lib_overlay.name.clone(),
                 has_config: true,
                 flat: true,
+                relative_path: lib_overlay.name.clone().into(),
             });
         }
     }
@@ -239,20 +240,14 @@ pub(crate) fn browse_overlays(
         let base_path = mgr
             .get_source_base_path(&source.name)
             .ok_or_else(|| anyhow::anyhow!("Source base path not found: {}", source.name))?;
-        let overlay_path = base_path.join(&o.org).join(&o.repo).join(&o.name);
         let commit = mgr.get_source_commit(&source.name)?;
 
-        Ok(ResolvedSource {
-            path: overlay_path,
-            source_info: OverlaySource::overlay_repo_full(
-                o.org.clone(),
-                o.repo.clone(),
-                o.name.clone(),
-                commit,
-                ResolvedVia::Direct,
-                source.name.clone(),
-            ),
-        })
+        Ok(resolve_configured_browse_source(
+            base_path,
+            o,
+            commit,
+            source.name.clone(),
+        ))
     };
 
     browse_and_apply(
@@ -400,16 +395,7 @@ fn browse_local_source(
     };
 
     let local_base = local_path.to_path_buf();
-    let build_source_info = move |o: &AvailableOverlay| {
-        let overlay_path = local_base.join(o.relative_path());
-        if !overlay_path.exists() {
-            bail!("Overlay directory not found: {}", overlay_path.display());
-        }
-        Ok(ResolvedSource {
-            path: overlay_path,
-            source_info: OverlaySource::local(local_base.clone()),
-        })
-    };
+    let build_source_info = move |o: &AvailableOverlay| resolve_local_browse_source(&local_base, o);
 
     browse_and_apply(
         overlays,
@@ -420,6 +406,43 @@ fn browse_local_source(
         show_all,
         build_source_info,
     )
+}
+
+fn resolve_local_browse_source(local_base: &Path, o: &AvailableOverlay) -> Result<ResolvedSource> {
+    let overlay_path = local_base.join(o.relative_path());
+    if !overlay_path.exists() {
+        bail!("Overlay directory not found: {}", overlay_path.display());
+    }
+    Ok(ResolvedSource {
+        path: overlay_path.clone(),
+        source_info: OverlaySource::local(overlay_path),
+    })
+}
+
+fn resolve_configured_browse_source(
+    base_path: &Path,
+    o: &AvailableOverlay,
+    commit: impl Into<String>,
+    source_name: impl Into<String>,
+) -> ResolvedSource {
+    let overlay_path = base_path.join(o.relative_path());
+    let source_info = if o.flat {
+        OverlaySource::local(overlay_path.clone())
+    } else {
+        OverlaySource::overlay_repo_full(
+            o.org.clone(),
+            o.repo.clone(),
+            o.name.clone(),
+            commit.into(),
+            ResolvedVia::Direct,
+            source_name.into(),
+        )
+    };
+
+    ResolvedSource {
+        path: overlay_path,
+        source_info,
+    }
 }
 
 /// Shared logic for browse: filter, display, select, and apply overlays.
@@ -511,4 +534,92 @@ where
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat_overlay(name: &str, relative_path: &str) -> AvailableOverlay {
+        AvailableOverlay {
+            org: String::new(),
+            repo: String::new(),
+            name: name.to_string(),
+            has_config: false,
+            flat: true,
+            relative_path: PathBuf::from(relative_path),
+        }
+    }
+
+    fn structured_overlay() -> AvailableOverlay {
+        AvailableOverlay {
+            org: "owner".to_string(),
+            repo: "repo".to_string(),
+            name: "config".to_string(),
+            has_config: false,
+            flat: false,
+            relative_path: PathBuf::from("owner/repo/config"),
+        }
+    }
+
+    #[test]
+    fn local_browse_flat_subdirectory_records_overlay_path() {
+        let source = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(source.path().join("config-a")).unwrap();
+        let overlay = flat_overlay("config-a", "config-a");
+
+        let resolved = resolve_local_browse_source(source.path(), &overlay).unwrap();
+
+        assert_eq!(resolved.path, source.path().join("config-a"));
+        match resolved.source_info {
+            OverlaySource::Local { path } => assert_eq!(path, source.path().join("config-a")),
+            other => panic!("expected local source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn configured_browse_flat_subdirectory_records_local_overlay_path() {
+        let source = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(source.path().join("config-a")).unwrap();
+        let overlay = flat_overlay("config-a", "config-a");
+
+        let resolved =
+            resolve_configured_browse_source(source.path(), &overlay, "local", "local-flat");
+
+        assert_eq!(resolved.path, source.path().join("config-a"));
+        match resolved.source_info {
+            OverlaySource::Local { path } => assert_eq!(path, source.path().join("config-a")),
+            other => panic!("expected local source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn configured_browse_structured_preserves_overlay_repo_source() {
+        let source = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(source.path().join("owner/repo/config")).unwrap();
+        let overlay = structured_overlay();
+
+        let resolved =
+            resolve_configured_browse_source(source.path(), &overlay, "abc123", "shared");
+
+        assert_eq!(resolved.path, source.path().join("owner/repo/config"));
+        match resolved.source_info {
+            OverlaySource::OverlayRepo {
+                org,
+                repo,
+                name,
+                commit,
+                resolved_via,
+                source_name,
+            } => {
+                assert_eq!(org, "owner");
+                assert_eq!(repo, "repo");
+                assert_eq!(name, "config");
+                assert_eq!(commit, "abc123");
+                assert_eq!(resolved_via, Some(ResolvedVia::Direct));
+                assert_eq!(source_name.as_deref(), Some("shared"));
+            }
+            other => panic!("expected overlay repo source, got {other:?}"),
+        }
+    }
 }

--- a/src/cli/commands/move.rs
+++ b/src/cli/commands/move.rs
@@ -365,7 +365,7 @@ fn resolve_source_path(target: &Path, source: &OverlaySource) -> Result<PathBuf>
             let library_path = library::get_library_path(target)?;
             Ok(library_path.join(name))
         }
-        OverlaySource::Local { path } => Ok(path.clone()),
+        OverlaySource::Local { path, .. } => Ok(path.clone()),
         OverlaySource::GitHub { .. } => {
             bail!("Cannot move a GitHub-sourced overlay. Import it to the library first.")
         }

--- a/src/create.rs
+++ b/src/create.rs
@@ -63,7 +63,7 @@ pub(crate) fn restore_overlays(
     for state in &external_states {
         println!("  - {}", state.name);
         match &state.source {
-            OverlaySource::Local { path } => {
+            OverlaySource::Local { path, .. } => {
                 println!("    Source: {}", path.display());
             }
             OverlaySource::GitHub { url, git_ref, .. } => {
@@ -93,7 +93,7 @@ pub(crate) fn restore_overlays(
     // Restore each overlay
     for state in external_states {
         let source_str = match &state.source {
-            OverlaySource::Local { path } => path.to_string_lossy().to_string(),
+            OverlaySource::Local { path, .. } => path.to_string_lossy().to_string(),
             OverlaySource::GitHub {
                 url,
                 owner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1575,7 +1575,7 @@ mod tests {
 
             assert_eq!(source.path, PathBuf::from("/some/path"));
             match source.source_info {
-                OverlaySource::Local { path } => {
+                OverlaySource::Local { path, .. } => {
                     assert_eq!(path, PathBuf::from("/origin"));
                 }
                 _ => panic!("Expected Local source"),
@@ -3870,6 +3870,7 @@ mod tests {
                 path: overlay.path().to_path_buf(),
                 source_info: OverlaySource::Local {
                     path: overlay.path().to_path_buf(),
+                    source_name: None,
                 },
             };
             apply_resolved_overlay(
@@ -3892,6 +3893,7 @@ mod tests {
                 path: overlay2.path().to_path_buf(),
                 source_info: OverlaySource::Local {
                     path: overlay2.path().to_path_buf(),
+                    source_name: None,
                 },
             };
             apply_resolved_overlay(
@@ -3925,6 +3927,7 @@ mod tests {
                 path: overlay.path().to_path_buf(),
                 source_info: OverlaySource::Local {
                     path: overlay.path().to_path_buf(),
+                    source_name: None,
                 },
             };
             apply_resolved_overlay(
@@ -3950,6 +3953,7 @@ mod tests {
                 path: overlay2.path().to_path_buf(),
                 source_info: OverlaySource::Local {
                     path: overlay2.path().to_path_buf(),
+                    source_name: None,
                 },
             };
             apply_multiple_overlays(

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -413,36 +413,6 @@ impl OverlayRepoManager {
         Ok(path)
     }
 
-    /// Get the path to a specific overlay with upstream fallback.
-    ///
-    /// Resolution order:
-    /// 1. Try exact match: `org/repo/name`
-    /// 2. If upstream provided, try: `upstream.org/upstream.repo/name`
-    ///
-    /// Returns the path and how it was resolved.
-    #[allow(dead_code)]
-    pub(crate) fn get_overlay_path_with_fallback(
-        &self,
-        org: &str,
-        repo: &str,
-        name: &str,
-        upstream: Option<&UpstreamInfo>,
-    ) -> Result<(PathBuf, ResolvedVia)> {
-        if let Some(found) = self.find_overlay_path_with_fallback(org, repo, name, upstream)? {
-            return Ok(found);
-        }
-
-        // Nothing found - provide helpful error
-        let mut msg = format!("Overlay not found: {org}/{repo}/{name}");
-        if let Some(up) = upstream {
-            use std::fmt::Write;
-            let up_org = &up.org;
-            let up_repo = &up.repo;
-            let _ = write!(msg, "\nAlso checked upstream: {up_org}/{up_repo}/{name}");
-        }
-        bail!("{msg}");
-    }
-
     /// Find the path to a specific overlay with upstream fallback.
     ///
     /// Returns `Ok(None)` only when the overlay is absent. Invalid input and
@@ -1161,7 +1131,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_overlay_path_with_fallback_direct_match() {
+    fn test_find_overlay_path_with_fallback_direct_match() {
         let temp = TempDir::new().unwrap();
         let repo_path = temp.path().join("overlay-repo");
         fs::create_dir_all(repo_path.join(".git")).unwrap();
@@ -1180,20 +1150,21 @@ mod tests {
         });
 
         let (path, resolved_via) = manager
-            .get_overlay_path_with_fallback(
+            .find_overlay_path_with_fallback(
                 "tylerbutler",
                 "FluidFramework",
                 "claude-config",
                 upstream.as_ref(),
             )
-            .unwrap();
+            .unwrap()
+            .expect("overlay should be found");
 
         assert!(path.ends_with("tylerbutler/FluidFramework/claude-config"));
         assert_eq!(resolved_via, crate::state::ResolvedVia::Direct);
     }
 
     #[test]
-    fn test_get_overlay_path_with_fallback_uses_upstream() {
+    fn test_find_overlay_path_with_fallback_uses_upstream() {
         let temp = TempDir::new().unwrap();
         let repo_path = temp.path().join("overlay-repo");
         fs::create_dir_all(repo_path.join(".git")).unwrap();
@@ -1213,20 +1184,21 @@ mod tests {
         });
 
         let (path, resolved_via) = manager
-            .get_overlay_path_with_fallback(
+            .find_overlay_path_with_fallback(
                 "tylerbutler",
                 "FluidFramework",
                 "claude-config",
                 upstream.as_ref(),
             )
-            .unwrap();
+            .unwrap()
+            .expect("upstream overlay should be found");
 
         assert!(path.ends_with("microsoft/FluidFramework/claude-config"));
         assert_eq!(resolved_via, crate::state::ResolvedVia::Upstream);
     }
 
     #[test]
-    fn test_get_overlay_path_with_fallback_no_upstream_fails() {
+    fn test_find_overlay_path_with_fallback_no_upstream_returns_none() {
         let temp = TempDir::new().unwrap();
         let repo_path = temp.path().join("overlay-repo");
         fs::create_dir_all(repo_path.join(".git")).unwrap();
@@ -1239,14 +1211,11 @@ mod tests {
 
         let manager = OverlayRepoManager::new(config).unwrap();
 
-        let result = manager.get_overlay_path_with_fallback(
-            "tylerbutler",
-            "FluidFramework",
-            "claude-config",
-            None,
-        );
+        let result = manager
+            .find_overlay_path_with_fallback("tylerbutler", "FluidFramework", "claude-config", None)
+            .unwrap();
 
-        assert!(result.is_err());
+        assert!(result.is_none());
     }
 
     #[test]

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -59,6 +59,8 @@ pub(crate) struct AvailableOverlay {
     ///
     /// Flat overlays use a simpler directory structure without org/repo nesting.
     pub(crate) flat: bool,
+    /// Source-relative path to the overlay directory.
+    pub(crate) relative_path: PathBuf,
 }
 
 impl std::fmt::Display for AvailableOverlay {
@@ -86,13 +88,11 @@ impl AvailableOverlay {
     ///
     /// For structured overlays: `org/repo/name`
     /// For flat overlays: just `name` (or empty if the base dir itself is the overlay)
-    pub(crate) fn relative_path(&self) -> std::path::PathBuf {
+    pub(crate) fn relative_path(&self) -> PathBuf {
         if self.flat {
-            std::path::PathBuf::from(&self.name)
+            self.relative_path.clone()
         } else {
-            std::path::PathBuf::from(&self.org)
-                .join(&self.repo)
-                .join(&self.name)
+            PathBuf::from(&self.org).join(&self.repo).join(&self.name)
         }
     }
 }
@@ -323,6 +323,9 @@ impl OverlayRepoManager {
 
                     // Check if it has a config file
                     let has_config = overlay_path.join("repoverlay.ccl").exists();
+                    let relative_path = PathBuf::from(&org_name)
+                        .join(&repo_name)
+                        .join(&overlay_name);
 
                     overlays.push(AvailableOverlay {
                         org: org_name.clone(),
@@ -330,6 +333,7 @@ impl OverlayRepoManager {
                         name: overlay_name,
                         has_config,
                         flat: false,
+                        relative_path,
                     });
                 }
             }
@@ -661,6 +665,7 @@ mod tests {
             name: "claude-config".to_string(),
             has_config: true,
             flat: false,
+            relative_path: PathBuf::from("microsoft/FluidFramework/claude-config"),
         };
 
         let cloned = overlay.clone();
@@ -1612,6 +1617,7 @@ mod tests {
             name: "vscode-setup".to_string(),
             has_config: true,
             flat: false,
+            relative_path: PathBuf::from("microsoft/FluidFramework/vscode-setup"),
         };
         assert_eq!(o.to_string(), "microsoft/FluidFramework/vscode-setup");
     }
@@ -1624,6 +1630,7 @@ mod tests {
             name: "vscode-setup".to_string(),
             has_config: true,
             flat: false,
+            relative_path: PathBuf::from("microsoft/FluidFramework/vscode-setup"),
         };
         let bold = o.display_bold();
         assert!(bold.contains("microsoft"));
@@ -1640,6 +1647,7 @@ mod tests {
                 name: "claude-config".to_string(),
                 has_config: true,
                 flat: false,
+                relative_path: PathBuf::from("microsoft/FluidFramework/claude-config"),
             },
             AvailableOverlay {
                 org: "owner".to_string(),
@@ -1647,6 +1655,7 @@ mod tests {
                 name: "my-overlay".to_string(),
                 has_config: false,
                 flat: false,
+                relative_path: PathBuf::from("owner/repo/my-overlay"),
             },
         ];
         let output: Vec<String> = overlays.iter().map(|o| format!("{o}")).collect();

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -58,14 +58,14 @@ pub(crate) struct AvailableOverlay {
     /// Whether this overlay comes from a flat (non-nested) source layout.
     ///
     /// Flat overlays use a simpler directory structure without org/repo nesting.
-    pub(crate) flat: bool,
+    flat: bool,
     /// Source-relative path to the overlay directory.
-    pub(crate) relative_path: PathBuf,
+    source_relative_path: PathBuf,
 }
 
 impl std::fmt::Display for AvailableOverlay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.flat {
+        if self.is_flat() {
             write!(f, "{}", self.name)
         } else {
             write!(f, "{}/{}/{}", self.org, self.repo, self.name)
@@ -77,23 +77,70 @@ impl AvailableOverlay {
     /// Format the overlay path for display with the overlay name in bold.
     pub(crate) fn display_bold(&self) -> String {
         use colored::Colorize;
-        if self.flat {
+        if self.is_flat() {
             self.name.bold().to_string()
         } else {
             format!("{}/{}/{}", self.org, self.repo, self.name.bold())
         }
     }
 
+    /// Create metadata for an overlay in structured `org/repo/name` layout.
+    pub(crate) fn structured(org: String, repo: String, name: String, has_config: bool) -> Self {
+        let source_relative_path = PathBuf::from(&org).join(&repo).join(&name);
+        Self {
+            org,
+            repo,
+            name,
+            has_config,
+            flat: false,
+            source_relative_path,
+        }
+    }
+
+    /// Create metadata for an overlay in flat source layout.
+    pub(crate) const fn flat(
+        name: String,
+        source_relative_path: PathBuf,
+        has_config: bool,
+    ) -> Self {
+        Self {
+            org: String::new(),
+            repo: String::new(),
+            name,
+            has_config,
+            flat: true,
+            source_relative_path,
+        }
+    }
+
+    /// Create metadata for a synthetic flat overlay namespace, such as the in-repo library.
+    pub(crate) const fn synthetic_flat(
+        org: String,
+        name: String,
+        source_relative_path: PathBuf,
+        has_config: bool,
+    ) -> Self {
+        Self {
+            org,
+            repo: String::new(),
+            name,
+            has_config,
+            flat: true,
+            source_relative_path,
+        }
+    }
+
+    /// Whether this overlay comes from a flat source layout.
+    pub(crate) const fn is_flat(&self) -> bool {
+        self.flat
+    }
+
     /// Returns the relative path from the source base directory to this overlay.
     ///
     /// For structured overlays: `org/repo/name`
     /// For flat overlays: just `name` (or empty if the base dir itself is the overlay)
-    pub(crate) fn relative_path(&self) -> PathBuf {
-        if self.flat {
-            self.relative_path.clone()
-        } else {
-            PathBuf::from(&self.org).join(&self.repo).join(&self.name)
-        }
+    pub(crate) fn source_relative_path(&self) -> PathBuf {
+        self.source_relative_path.clone()
     }
 }
 
@@ -323,18 +370,12 @@ impl OverlayRepoManager {
 
                     // Check if it has a config file
                     let has_config = overlay_path.join("repoverlay.ccl").exists();
-                    let relative_path = PathBuf::from(&org_name)
-                        .join(&repo_name)
-                        .join(&overlay_name);
-
-                    overlays.push(AvailableOverlay {
-                        org: org_name.clone(),
-                        repo: repo_name.clone(),
-                        name: overlay_name,
+                    overlays.push(AvailableOverlay::structured(
+                        org_name.clone(),
+                        repo_name.clone(),
+                        overlay_name,
                         has_config,
-                        flat: false,
-                        relative_path,
-                    });
+                    ));
                 }
             }
         }
@@ -379,6 +420,7 @@ impl OverlayRepoManager {
     /// 2. If upstream provided, try: `upstream.org/upstream.repo/name`
     ///
     /// Returns the path and how it was resolved.
+    #[allow(dead_code)]
     pub(crate) fn get_overlay_path_with_fallback(
         &self,
         org: &str,
@@ -386,23 +428,8 @@ impl OverlayRepoManager {
         name: &str,
         upstream: Option<&UpstreamInfo>,
     ) -> Result<(PathBuf, ResolvedVia)> {
-        validate_path_component(org, "org")?;
-        validate_path_component(repo, "repo")?;
-        validate_path_component(name, "overlay name")?;
-        // Try exact match first
-        let direct_path = self.repo_path.join(org).join(repo).join(name);
-        if direct_path.exists() {
-            return Ok((direct_path, ResolvedVia::Direct));
-        }
-
-        // Try upstream fallback if available
-        if let Some(up) = upstream {
-            validate_path_component(&up.org, "upstream org")?;
-            validate_path_component(&up.repo, "upstream repo")?;
-            let upstream_path = self.repo_path.join(&up.org).join(&up.repo).join(name);
-            if upstream_path.exists() {
-                return Ok((upstream_path, ResolvedVia::Upstream));
-            }
+        if let Some(found) = self.find_overlay_path_with_fallback(org, repo, name, upstream)? {
+            return Ok(found);
         }
 
         // Nothing found - provide helpful error
@@ -414,6 +441,40 @@ impl OverlayRepoManager {
             let _ = write!(msg, "\nAlso checked upstream: {up_org}/{up_repo}/{name}");
         }
         bail!("{msg}");
+    }
+
+    /// Find the path to a specific overlay with upstream fallback.
+    ///
+    /// Returns `Ok(None)` only when the overlay is absent. Invalid input and
+    /// filesystem/config errors are returned as errors so callers do not treat
+    /// them as "not found".
+    pub(crate) fn find_overlay_path_with_fallback(
+        &self,
+        org: &str,
+        repo: &str,
+        name: &str,
+        upstream: Option<&UpstreamInfo>,
+    ) -> Result<Option<(PathBuf, ResolvedVia)>> {
+        validate_path_component(org, "org")?;
+        validate_path_component(repo, "repo")?;
+        validate_path_component(name, "overlay name")?;
+        // Try exact match first
+        let direct_path = self.repo_path.join(org).join(repo).join(name);
+        if direct_path.exists() {
+            return Ok(Some((direct_path, ResolvedVia::Direct)));
+        }
+
+        // Try upstream fallback if available
+        if let Some(up) = upstream {
+            validate_path_component(&up.org, "upstream org")?;
+            validate_path_component(&up.repo, "upstream repo")?;
+            let upstream_path = self.repo_path.join(&up.org).join(&up.repo).join(name);
+            if upstream_path.exists() {
+                return Ok(Some((upstream_path, ResolvedVia::Upstream)));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Stage an overlay for publishing.
@@ -659,20 +720,51 @@ mod tests {
 
     #[test]
     fn test_available_overlay_clone() {
-        let overlay = AvailableOverlay {
-            org: "microsoft".to_string(),
-            repo: "FluidFramework".to_string(),
-            name: "claude-config".to_string(),
-            has_config: true,
-            flat: false,
-            relative_path: PathBuf::from("microsoft/FluidFramework/claude-config"),
-        };
+        let overlay = AvailableOverlay::structured(
+            "microsoft".to_string(),
+            "FluidFramework".to_string(),
+            "claude-config".to_string(),
+            true,
+        );
 
         let cloned = overlay.clone();
         assert_eq!(cloned.org, overlay.org);
         assert_eq!(cloned.repo, overlay.repo);
         assert_eq!(cloned.name, overlay.name);
         assert_eq!(cloned.has_config, overlay.has_config);
+    }
+
+    #[test]
+    fn available_overlay_structured_computes_source_relative_path() {
+        let overlay = AvailableOverlay::structured(
+            "owner".to_string(),
+            "repo".to_string(),
+            "config".to_string(),
+            true,
+        );
+
+        assert_eq!(overlay.to_string(), "owner/repo/config");
+        assert_eq!(
+            overlay.source_relative_path(),
+            PathBuf::from("owner").join("repo").join("config")
+        );
+        assert!(!overlay.is_flat());
+    }
+
+    #[test]
+    fn available_overlay_flat_uses_supplied_source_relative_path() {
+        let overlay = AvailableOverlay::flat(
+            "config-a".to_string(),
+            PathBuf::from("nested/config-a"),
+            false,
+        );
+
+        assert_eq!(overlay.to_string(), "config-a");
+        assert_eq!(
+            overlay.source_relative_path(),
+            PathBuf::from("nested/config-a")
+        );
+        assert!(overlay.is_flat());
     }
 
     #[test]
@@ -1158,6 +1250,38 @@ mod tests {
     }
 
     #[test]
+    fn find_overlay_path_with_fallback_returns_none_for_absent_overlay() {
+        let temp = TempDir::new().unwrap();
+        let config = OverlayRepoConfig {
+            url: "https://github.com/org/overlays".to_string(),
+            local_path: Some(temp.path().to_path_buf()),
+        };
+        let manager = OverlayRepoManager::new(config).unwrap();
+
+        let found = manager
+            .find_overlay_path_with_fallback("org", "repo", "missing", None)
+            .unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_overlay_path_with_fallback_propagates_invalid_components() {
+        let temp = TempDir::new().unwrap();
+        let config = OverlayRepoConfig {
+            url: "https://github.com/org/overlays".to_string(),
+            local_path: Some(temp.path().to_path_buf()),
+        };
+        let manager = OverlayRepoManager::new(config).unwrap();
+
+        let err = manager
+            .find_overlay_path_with_fallback("org", "repo", "../escape", None)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("path traversal"));
+    }
+
+    #[test]
     fn test_get_current_commit_on_non_git_directory() {
         let temp = TempDir::new().unwrap();
         let repo_path = temp.path().join("not-a-repo");
@@ -1611,27 +1735,23 @@ mod tests {
 
     #[test]
     fn available_overlay_display() {
-        let o = AvailableOverlay {
-            org: "microsoft".to_string(),
-            repo: "FluidFramework".to_string(),
-            name: "vscode-setup".to_string(),
-            has_config: true,
-            flat: false,
-            relative_path: PathBuf::from("microsoft/FluidFramework/vscode-setup"),
-        };
+        let o = AvailableOverlay::structured(
+            "microsoft".to_string(),
+            "FluidFramework".to_string(),
+            "vscode-setup".to_string(),
+            true,
+        );
         assert_eq!(o.to_string(), "microsoft/FluidFramework/vscode-setup");
     }
 
     #[test]
     fn available_overlay_display_bold_contains_name() {
-        let o = AvailableOverlay {
-            org: "microsoft".to_string(),
-            repo: "FluidFramework".to_string(),
-            name: "vscode-setup".to_string(),
-            has_config: true,
-            flat: false,
-            relative_path: PathBuf::from("microsoft/FluidFramework/vscode-setup"),
-        };
+        let o = AvailableOverlay::structured(
+            "microsoft".to_string(),
+            "FluidFramework".to_string(),
+            "vscode-setup".to_string(),
+            true,
+        );
         let bold = o.display_bold();
         assert!(bold.contains("microsoft"));
         assert!(bold.contains("FluidFramework"));
@@ -1641,22 +1761,18 @@ mod tests {
     #[test]
     fn snapshot_available_overlay_display() {
         let overlays = [
-            AvailableOverlay {
-                org: "microsoft".to_string(),
-                repo: "FluidFramework".to_string(),
-                name: "claude-config".to_string(),
-                has_config: true,
-                flat: false,
-                relative_path: PathBuf::from("microsoft/FluidFramework/claude-config"),
-            },
-            AvailableOverlay {
-                org: "owner".to_string(),
-                repo: "repo".to_string(),
-                name: "my-overlay".to_string(),
-                has_config: false,
-                flat: false,
-                relative_path: PathBuf::from("owner/repo/my-overlay"),
-            },
+            AvailableOverlay::structured(
+                "microsoft".to_string(),
+                "FluidFramework".to_string(),
+                "claude-config".to_string(),
+                true,
+            ),
+            AvailableOverlay::structured(
+                "owner".to_string(),
+                "repo".to_string(),
+                "my-overlay".to_string(),
+                false,
+            ),
         ];
         let output: Vec<String> = overlays.iter().map(|o| format!("{o}")).collect();
         insta::assert_snapshot!(output.join("\n"));

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -194,6 +194,16 @@ pub(crate) fn resolve_source(
         );
     }
 
+    if source_filter.is_some() && is_unqualified_overlay_name(source_str) {
+        return resolve_one_part_from_configured_source(
+            source_str,
+            target_path,
+            source_filter,
+            update,
+        )
+        .map(ResolvedSources::Single);
+    }
+
     // Parse input into structured reference
     let reference = SourceReference::parse(source_str);
     debug!("parsed reference: {reference:?}");
@@ -274,6 +284,11 @@ pub(crate) fn resolve_source(
             None,
         ),
 
+        SourceReference::OnePart { username } if source_filter.is_some() => {
+            resolve_one_part_from_configured_source(&username, target_path, source_filter, update)
+                .map(ResolvedSources::Single)
+        }
+
         SourceReference::OnePart { username } => {
             // Before treating as a GitHub username, check if this is an applied
             // overlay name that could be resolved from its source. This catches
@@ -313,6 +328,13 @@ pub(crate) fn resolve_source(
             )
         }
     }
+}
+
+fn is_unqualified_overlay_name(source_str: &str) -> bool {
+    !source_str.is_empty()
+        && !source_str.contains('/')
+        && !source_str.starts_with('.')
+        && source_str != "~"
 }
 
 /// Resolve a GitHub URL source.
@@ -663,12 +685,16 @@ pub(crate) fn list_overlays_from_path(repo_path: &Path) -> Result<Vec<AvailableO
         for (repo_dir, repo_name) in visible_subdirs(&org_path)? {
             for (overlay_path, overlay_name) in visible_subdirs(&repo_dir)? {
                 let has_config = overlay_path.join("repoverlay.ccl").exists();
+                let relative_path = PathBuf::from(&org_name)
+                    .join(&repo_name)
+                    .join(&overlay_name);
                 overlays.push(AvailableOverlay {
                     org: org_name.clone(),
                     repo: repo_name.clone(),
                     name: overlay_name,
                     has_config,
                     flat: false,
+                    relative_path,
                 });
             }
         }
@@ -831,18 +857,24 @@ fn resolve_from_sources_with_suggestions(
 ) -> Result<ResolvedSource> {
     let manager = sources::SourceManager::new(sources.to_vec(), repo_root)?;
 
-    // Ensure all sources are cloned and up-to-date
-    manager.ensure_all_cloned()?;
-
-    if update {
-        println!("{} overlay sources...", "Updating".blue().bold());
-        manager.pull_all()?;
-    } else {
-        debug!("skipping overlay source update (--no-update)");
-    }
+    prepare_sources_for_resolution(&manager, sources, source_filter, update)?;
 
     // Resolve overlay from sources
     if let Some(resolved) = manager.resolve(org, repo, name, upstream, source_filter)? {
+        if resolved.flat {
+            let source_suffix = format!(" [{}]", resolved.source.name).cyan().to_string();
+            println!(
+                "{} overlay: {}{}",
+                "Resolving".blue().bold(),
+                name,
+                source_suffix,
+            );
+            return Ok(ResolvedSource {
+                path: resolved.path.clone(),
+                source_info: OverlaySource::local(resolved.path),
+            });
+        }
+
         // Determine actual org/repo for state tracking
         let via_upstream = resolved.resolved_via == state::ResolvedVia::Upstream;
         let (actual_org, actual_repo) = match (upstream, via_upstream) {
@@ -885,6 +917,137 @@ fn resolve_from_sources_with_suggestions(
     let source_list = manager.source_names().join(", ");
     let error_msg = format_not_found_error(org, repo, name, &suggestions, Some(&source_list));
     bail!("{error_msg}")
+}
+
+/// Resolve a one-part overlay name from an explicitly configured source.
+///
+/// Used for `apply <name> --from <source>` before falling back to GitHub username
+/// expansion, so flat local sources can be addressed by overlay name.
+fn resolve_one_part_from_configured_source(
+    name: &str,
+    target_path: Option<&Path>,
+    source_filter: Option<&str>,
+    update: bool,
+) -> Result<ResolvedSource> {
+    let config = config::load_config(target_path)?;
+    if config.sources.is_empty() {
+        bail!(
+            "Overlay source not configured.\n\n\
+             Add a source with: repoverlay source add <url-or-path>"
+        );
+    }
+
+    let manager = sources::SourceManager::new(config.sources.clone(), target_path)?;
+    prepare_sources_for_resolution(&manager, &config.sources, source_filter, update)?;
+
+    let upstream = target_path.and_then(|p| detect_upstream(p).ok()).flatten();
+    if let Some((org, repo)) = target_path
+        .and_then(|p| upstream::detect_repo_identity(p).ok().flatten())
+        .and_then(|identity| identity.origin.or(identity.upstream))
+        && let Some(resolved) =
+            manager.resolve(&org, &repo, name, upstream.as_ref(), source_filter)?
+        && !resolved.flat
+    {
+        let via_upstream = resolved.resolved_via == state::ResolvedVia::Upstream;
+        let (actual_org, actual_repo) = match (upstream.as_ref(), via_upstream) {
+            (Some(up), true) => (up.org.clone(), up.repo.clone()),
+            _ => (org, repo),
+        };
+        let via_suffix = if via_upstream {
+            " (via upstream)".dimmed().to_string()
+        } else {
+            String::new()
+        };
+        let source_suffix = format!(" [{}]", resolved.source.name).cyan().to_string();
+        println!(
+            "{} overlay: {}/{}/{}{}{}",
+            "Resolving".blue().bold(),
+            actual_org,
+            actual_repo,
+            name,
+            via_suffix,
+            source_suffix,
+        );
+
+        return Ok(ResolvedSource {
+            path: resolved.path,
+            source_info: OverlaySource::overlay_repo_full(
+                actual_org,
+                actual_repo,
+                name.to_string(),
+                resolved.commit,
+                resolved.resolved_via,
+                resolved.source.name,
+            ),
+        });
+    }
+
+    if let Some(resolved) = manager.resolve("", "", name, None, source_filter)? {
+        let source_suffix = format!(" [{}]", resolved.source.name).cyan().to_string();
+        println!(
+            "{} overlay: {}{}",
+            "Resolving".blue().bold(),
+            name,
+            source_suffix,
+        );
+
+        let source_info = if resolved.flat {
+            OverlaySource::local(resolved.path.clone())
+        } else {
+            OverlaySource::overlay_repo_full(
+                String::new(),
+                String::new(),
+                name.to_string(),
+                resolved.commit,
+                resolved.resolved_via,
+                resolved.source.name,
+            )
+        };
+
+        return Ok(ResolvedSource {
+            path: resolved.path,
+            source_info,
+        });
+    }
+
+    let suggestions = get_fuzzy_suggestions_multi_source(&manager, "", "", name);
+    let source_list = manager.source_names().join(", ");
+    let error_msg = format_not_found_error("", "", name, &suggestions, Some(&source_list));
+    bail!("{error_msg}")
+}
+
+fn prepare_sources_for_resolution(
+    manager: &sources::SourceManager,
+    sources: &[config::Source],
+    source_filter: Option<&str>,
+    update: bool,
+) -> Result<()> {
+    if selected_sources_are_all_local(sources, source_filter) {
+        debug!("skipping overlay source clone/update for local-only source selection");
+        return Ok(());
+    }
+
+    manager.ensure_all_cloned()?;
+
+    if update {
+        println!("{} overlay sources...", "Updating".blue().bold());
+        manager.pull_all()?;
+    } else {
+        debug!("skipping overlay source update (--no-update)");
+    }
+
+    Ok(())
+}
+
+fn selected_sources_are_all_local(sources: &[config::Source], source_filter: Option<&str>) -> bool {
+    if let Some(filter_name) = source_filter {
+        return sources
+            .iter()
+            .find(|source| source.name == filter_name)
+            .is_none_or(config::Source::is_local);
+    }
+
+    !sources.is_empty() && sources.iter().all(config::Source::is_local)
 }
 
 /// Get fuzzy suggestions for overlay names from multi-source config.
@@ -1036,6 +1199,46 @@ mod tests {
                     assert_eq!(v[1].path, PathBuf::from("/path/b"));
                 }
                 ResolvedSources::Single(_) => panic!("Expected Multiple variant"),
+            }
+        }
+    }
+
+    mod configured_source_tests {
+        use super::*;
+
+        #[test]
+        fn one_part_with_source_filter_resolves_flat_local_source() {
+            let temp = TempDir::new().unwrap();
+            let repo_root = temp.path();
+            let local_source = repo_root.join("overlays");
+            let overlay = local_source.join("config-a");
+            fs::create_dir_all(&overlay).unwrap();
+            fs::write(overlay.join(".envrc"), "export A=1").unwrap();
+            config::save_repo_config(
+                repo_root,
+                &config::RepoverlayConfig {
+                    sources: vec![config::Source {
+                        name: "local".to_string(),
+                        url: None,
+                        path: Some(PathBuf::from("overlays")),
+                    }],
+                    library_path: None,
+                },
+            )
+            .unwrap();
+
+            let resolved =
+                resolve_source("config-a", None, false, Some(repo_root), Some("local")).unwrap();
+
+            match resolved {
+                ResolvedSources::Single(source) => {
+                    assert_eq!(source.path, overlay);
+                    match source.source_info {
+                        OverlaySource::Local { path } => assert_eq!(path, overlay),
+                        other => panic!("expected local source, got {other:?}"),
+                    }
+                }
+                ResolvedSources::Multiple(_) => panic!("expected single source"),
             }
         }
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -685,17 +685,12 @@ pub(crate) fn list_overlays_from_path(repo_path: &Path) -> Result<Vec<AvailableO
         for (repo_dir, repo_name) in visible_subdirs(&org_path)? {
             for (overlay_path, overlay_name) in visible_subdirs(&repo_dir)? {
                 let has_config = overlay_path.join("repoverlay.ccl").exists();
-                let relative_path = PathBuf::from(&org_name)
-                    .join(&repo_name)
-                    .join(&overlay_name);
-                overlays.push(AvailableOverlay {
-                    org: org_name.clone(),
-                    repo: repo_name.clone(),
-                    name: overlay_name,
+                overlays.push(AvailableOverlay::structured(
+                    org_name.clone(),
+                    repo_name.clone(),
+                    overlay_name,
                     has_config,
-                    flat: false,
-                    relative_path,
-                });
+                ));
             }
         }
     }
@@ -861,17 +856,28 @@ fn resolve_from_sources_with_suggestions(
 
     // Resolve overlay from sources
     if let Some(resolved) = manager.resolve(org, repo, name, upstream, source_filter)? {
-        if resolved.flat {
+        if resolved.source.is_local() {
             let source_suffix = format!(" [{}]", resolved.source.name).cyan().to_string();
-            println!(
-                "{} overlay: {}{}",
-                "Resolving".blue().bold(),
-                name,
-                source_suffix,
-            );
+            if resolved.flat {
+                println!(
+                    "{} overlay: {}{}",
+                    "Resolving".blue().bold(),
+                    name,
+                    source_suffix,
+                );
+            } else {
+                println!(
+                    "{} overlay: {}/{}/{}{}",
+                    "Resolving".blue().bold(),
+                    org,
+                    repo,
+                    name,
+                    source_suffix,
+                );
+            }
             return Ok(ResolvedSource {
                 path: resolved.path.clone(),
-                source_info: OverlaySource::local(resolved.path),
+                source_info: OverlaySource::configured_local(resolved.path, resolved.source.name),
             });
         }
 
@@ -898,6 +904,13 @@ fn resolve_from_sources_with_suggestions(
             via_suffix,
             source_suffix,
         );
+
+        if resolved.source.is_local() {
+            return Ok(ResolvedSource {
+                path: resolved.path.clone(),
+                source_info: OverlaySource::configured_local(resolved.path, resolved.source.name),
+            });
+        }
 
         return Ok(ResolvedSource {
             path: resolved.path,
@@ -991,8 +1004,8 @@ fn resolve_one_part_from_configured_source(
             source_suffix,
         );
 
-        let source_info = if resolved.flat {
-            OverlaySource::local(resolved.path.clone())
+        let source_info = if resolved.source.is_local() {
+            OverlaySource::configured_local(resolved.path.clone(), resolved.source.name)
         } else {
             OverlaySource::overlay_repo_full(
                 String::new(),
@@ -1153,7 +1166,7 @@ mod tests {
 
             assert_eq!(source.path, PathBuf::from("/some/path"));
             match source.source_info {
-                OverlaySource::Local { path } => {
+                OverlaySource::Local { path, .. } => {
                     assert_eq!(path, PathBuf::from("/origin"));
                 }
                 _ => panic!("Expected Local source"),
@@ -1234,7 +1247,10 @@ mod tests {
                 ResolvedSources::Single(source) => {
                     assert_eq!(source.path, overlay);
                     match source.source_info {
-                        OverlaySource::Local { path } => assert_eq!(path, overlay),
+                        OverlaySource::Local { path, source_name } => {
+                            assert_eq!(path, overlay);
+                            assert_eq!(source_name.as_deref(), Some("local"));
+                        }
                         other => panic!("expected local source, got {other:?}"),
                     }
                 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -284,11 +284,6 @@ pub(crate) fn resolve_source(
             None,
         ),
 
-        SourceReference::OnePart { username } if source_filter.is_some() => {
-            resolve_one_part_from_configured_source(&username, target_path, source_filter, update)
-                .map(ResolvedSources::Single)
-        }
-
         SourceReference::OnePart { username } => {
             // Before treating as a GitHub username, check if this is an applied
             // overlay name that could be resolved from its source. This catches
@@ -330,6 +325,10 @@ pub(crate) fn resolve_source(
     }
 }
 
+/// Whether a source string looks like a bare overlay name (no path/URL syntax).
+///
+/// Used to short-circuit `apply <name> --from <source>` before
+/// `SourceReference::parse` rejects names that collide with cwd directories.
 fn is_unqualified_overlay_name(source_str: &str) -> bool {
     !source_str.is_empty()
         && !source_str.contains('/')
@@ -904,13 +903,6 @@ fn resolve_from_sources_with_suggestions(
             via_suffix,
             source_suffix,
         );
-
-        if resolved.source.is_local() {
-            return Ok(ResolvedSource {
-                path: resolved.path.clone(),
-                source_info: OverlaySource::configured_local(resolved.path, resolved.source.name),
-            });
-        }
 
         return Ok(ResolvedSource {
             path: resolved.path,

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -27,15 +27,6 @@ enum ManagedSourceBackend {
 }
 
 impl ManagedSourceBackend {
-    /// Whether this backend needs to be cloned before use.
-    #[allow(dead_code)] // Utility method for future use
-    fn needs_clone(&self) -> bool {
-        match self {
-            Self::Git(manager) => manager.needs_clone(),
-            Self::Local { .. } => false,
-        }
-    }
-
     /// The base path where overlays are stored.
     fn repo_path(&self) -> &Path {
         match self {
@@ -213,8 +204,8 @@ impl SourceManager {
                     if manager.needs_clone() {
                         continue;
                     }
-                    if let Ok((path, resolved_via)) =
-                        manager.get_overlay_path_with_fallback(org, repo, name, upstream)
+                    if let Some((path, resolved_via)) =
+                        manager.find_overlay_path_with_fallback(org, repo, name, upstream)?
                     {
                         let commit = manager.get_current_commit()?;
                         return Ok(Some(ResolvedOverlay {
@@ -282,7 +273,6 @@ impl SourceManager {
     ///
     /// Returns a list of (source, `resolved_via`) pairs for each source
     /// that has the overlay.
-    #[must_use]
     #[allow(dead_code)] // Utility method for future `resolve` command
     pub(crate) fn find_all_matches(
         &self,
@@ -290,7 +280,7 @@ impl SourceManager {
         repo: &str,
         name: &str,
         upstream: Option<&UpstreamInfo>,
-    ) -> Vec<(Source, ResolvedVia)> {
+    ) -> Result<Vec<(Source, ResolvedVia)>> {
         let mut matches = Vec::new();
 
         for ms in &self.sources {
@@ -299,8 +289,8 @@ impl SourceManager {
                     if manager.needs_clone() {
                         continue;
                     }
-                    if let Ok((_, resolved_via)) =
-                        manager.get_overlay_path_with_fallback(org, repo, name, upstream)
+                    if let Some((_, resolved_via)) =
+                        manager.find_overlay_path_with_fallback(org, repo, name, upstream)?
                     {
                         matches.push((ms.source.clone(), resolved_via));
                     }
@@ -323,7 +313,7 @@ impl SourceManager {
             }
         }
 
-        matches
+        Ok(matches)
     }
 
     /// List overlay names for a specific org/repo across all sources.
@@ -342,20 +332,16 @@ impl SourceManager {
                     if manager.needs_clone() {
                         continue;
                     }
-                    if let Ok(overlays) = manager.list_overlays_for_repo(org, repo) {
-                        for overlay in overlays {
-                            names.insert(OverlayName::try_new(overlay.name)?);
-                        }
+                    for overlay in manager.list_overlays_for_repo(org, repo)? {
+                        names.insert(OverlayName::try_new(overlay.name)?);
                     }
                 }
                 ManagedSourceBackend::Local { path: base_path } => {
-                    if let Ok(overlays) = list_overlays_in_dir(base_path) {
-                        for overlay in overlays {
-                            if overlay.org.eq_ignore_ascii_case(org)
-                                && overlay.repo.eq_ignore_ascii_case(repo)
-                            {
-                                names.insert(OverlayName::try_new(overlay.name)?);
-                            }
+                    for overlay in list_overlays_in_dir(base_path)? {
+                        if overlay.org.eq_ignore_ascii_case(org)
+                            && overlay.repo.eq_ignore_ascii_case(repo)
+                        {
+                            names.insert(OverlayName::try_new(overlay.name)?);
                         }
                     }
                 }
@@ -441,8 +427,8 @@ fn get_flat_overlay_path_in_dir(base: &Path, name: &str) -> Option<PathBuf> {
     let overlays = list_overlays_in_dir(base).ok()?;
     let overlay = overlays
         .iter()
-        .find(|overlay| overlay.flat && overlay.name.eq_ignore_ascii_case(name))?;
-    let overlay_path = base.join(overlay.relative_path());
+        .find(|overlay| overlay.is_flat() && overlay.name.eq_ignore_ascii_case(name))?;
+    let overlay_path = base.join(overlay.source_relative_path());
     let canonical_overlay = overlay_path.canonicalize().ok()?;
     let canonical_base = base.canonicalize().ok()?;
     if canonical_overlay.starts_with(canonical_base) && canonical_overlay.is_dir() {
@@ -572,20 +558,21 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
             continue;
         }
 
-        if path.is_dir() {
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("reading file type for {}", path.display()))?;
+
+        if file_type.is_dir() {
             has_overlay_dirs = true;
             let overlay_name = name;
             let has_config = path.join("repoverlay.ccl").exists();
             let relative_path = PathBuf::from(&overlay_name);
 
-            overlays.push(AvailableOverlay {
-                org: String::new(),
-                repo: String::new(),
-                name: overlay_name,
-                has_config,
-                flat: true,
+            overlays.push(AvailableOverlay::flat(
+                overlay_name,
                 relative_path,
-            });
+                has_config,
+            ));
         } else if is_overlay_file(&path) {
             has_root_files = true;
         }
@@ -599,14 +586,7 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
         );
         let has_config = base.join("repoverlay.ccl").exists();
 
-        overlays.push(AvailableOverlay {
-            org: String::new(),
-            repo: String::new(),
-            name: dir_name,
-            has_config,
-            flat: true,
-            relative_path: PathBuf::new(),
-        });
+        overlays.push(AvailableOverlay::flat(dir_name, PathBuf::new(), has_config));
     }
 
     overlays.sort_by(|a, b| a.name.cmp(&b.name));
@@ -680,18 +660,12 @@ fn list_overlays_in_structured_dir(base: &Path) -> Result<Vec<AvailableOverlay>>
 
                 let overlay_name = overlay_entry.file_name().to_string_lossy().to_string();
                 let has_config = overlay_path.join("repoverlay.ccl").exists();
-                let relative_path = PathBuf::from(&org_name)
-                    .join(&repo_name)
-                    .join(&overlay_name);
-
-                overlays.push(AvailableOverlay {
-                    org: org_name.clone(),
-                    repo: repo_name.clone(),
-                    name: overlay_name,
+                overlays.push(AvailableOverlay::structured(
+                    org_name.clone(),
+                    repo_name.clone(),
+                    overlay_name,
                     has_config,
-                    flat: false,
-                    relative_path,
-                });
+                ));
             }
         }
     }
@@ -1206,12 +1180,43 @@ mod tests {
         };
 
         // Should find in both sources
-        let matches =
-            manager.find_all_matches("microsoft", "FluidFramework", "claude-config", None);
+        let matches = manager
+            .find_all_matches("microsoft", "FluidFramework", "claude-config", None)
+            .unwrap();
 
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].0.name, "personal");
         assert_eq!(matches[1].0.name, "team");
+    }
+
+    #[test]
+    fn git_source_resolution_propagates_invalid_overlay_name() {
+        let temp = TempDir::new().unwrap();
+        let repo_path = temp.path().join("source");
+        fs::create_dir_all(repo_path.join(".git")).unwrap();
+        let source = Source {
+            name: "git-source".to_string(),
+            url: Some("file://dummy".to_string()),
+            path: None,
+        };
+        let manager = SourceManager {
+            sources: vec![ManagedSource {
+                source,
+                backend: ManagedSourceBackend::Git(
+                    OverlayRepoManager::new(OverlayRepoConfig {
+                        url: "file://dummy".to_string(),
+                        local_path: Some(repo_path),
+                    })
+                    .unwrap(),
+                ),
+            }],
+        };
+
+        let err = manager
+            .resolve("org", "repo", "../escape", None, None)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("path traversal"));
     }
 
     #[test]
@@ -2005,7 +2010,7 @@ mod tests {
         let overlays = list_overlays_in_dir(base).unwrap();
         assert_eq!(overlays.len(), 2);
 
-        assert!(overlays.iter().all(|o| o.flat));
+        assert!(overlays.iter().all(AvailableOverlay::is_flat));
         assert!(overlays.iter().all(|o| o.org.is_empty()));
         assert!(overlays.iter().all(|o| o.repo.is_empty()));
 
@@ -2033,7 +2038,7 @@ mod tests {
         assert_eq!(overlays.len(), 1);
 
         let overlay = &overlays[0];
-        assert!(overlay.flat);
+        assert!(overlay.is_flat());
         assert!(overlay.has_config);
         assert!(overlay.org.is_empty());
         assert!(overlay.repo.is_empty());
@@ -2050,8 +2055,8 @@ mod tests {
         let overlays = list_overlays_in_dir(base).unwrap();
 
         assert_eq!(overlays.len(), 1);
-        assert!(overlays[0].flat);
-        assert_eq!(overlays[0].relative_path(), PathBuf::new());
+        assert!(overlays[0].is_flat());
+        assert_eq!(overlays[0].source_relative_path(), PathBuf::new());
     }
 
     #[test]
@@ -2063,8 +2068,8 @@ mod tests {
         let overlays = list_overlays_in_dir(base).unwrap();
 
         assert_eq!(overlays.len(), 1);
-        assert!(overlays[0].flat);
-        assert_eq!(overlays[0].relative_path(), PathBuf::new());
+        assert!(overlays[0].is_flat());
+        assert_eq!(overlays[0].source_relative_path(), PathBuf::new());
     }
 
     #[test]
@@ -2080,7 +2085,7 @@ mod tests {
 
         assert_eq!(overlays.len(), 1);
         assert_eq!(overlays[0].name, "config-a");
-        assert_eq!(overlays[0].relative_path(), Path::new("config-a"));
+        assert_eq!(overlays[0].source_relative_path(), Path::new("config-a"));
     }
 
     #[test]
@@ -2103,53 +2108,58 @@ mod tests {
         assert_eq!(overlays[0].name, "visible");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn flat_source_listing_ignores_symlinked_directories() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join(".envrc"), "export SECRET=1").unwrap();
+        symlink(&outside, source.join("escape")).unwrap();
+
+        let overlays = list_overlays_in_dir(&source).unwrap();
+
+        assert!(overlays.is_empty());
+    }
+
     #[test]
     fn test_flat_overlay_relative_path() {
         use crate::overlay_repo::AvailableOverlay;
 
-        let flat = AvailableOverlay {
-            org: String::new(),
-            repo: String::new(),
-            name: "my-config".to_string(),
-            has_config: true,
-            flat: true,
-            relative_path: PathBuf::from("my-config"),
-        };
-        assert_eq!(flat.relative_path(), Path::new("my-config"));
+        let flat =
+            AvailableOverlay::flat("my-config".to_string(), PathBuf::from("my-config"), true);
+        assert_eq!(flat.source_relative_path(), Path::new("my-config"));
 
-        let structured = AvailableOverlay {
-            org: "org".to_string(),
-            repo: "repo".to_string(),
-            name: "overlay".to_string(),
-            has_config: false,
-            flat: false,
-            relative_path: PathBuf::from("org/repo/overlay"),
-        };
-        assert_eq!(structured.relative_path(), Path::new("org/repo/overlay"));
+        let structured = AvailableOverlay::structured(
+            "org".to_string(),
+            "repo".to_string(),
+            "overlay".to_string(),
+            false,
+        );
+        assert_eq!(
+            structured.source_relative_path(),
+            Path::new("org/repo/overlay")
+        );
     }
 
     #[test]
     fn test_flat_overlay_display() {
         use crate::overlay_repo::AvailableOverlay;
 
-        let flat = AvailableOverlay {
-            org: String::new(),
-            repo: String::new(),
-            name: "my-config".to_string(),
-            has_config: true,
-            flat: true,
-            relative_path: PathBuf::from("my-config"),
-        };
+        let flat =
+            AvailableOverlay::flat("my-config".to_string(), PathBuf::from("my-config"), true);
         assert_eq!(flat.to_string(), "my-config");
 
-        let structured = AvailableOverlay {
-            org: "org".to_string(),
-            repo: "repo".to_string(),
-            name: "overlay".to_string(),
-            has_config: false,
-            flat: false,
-            relative_path: PathBuf::from("org/repo/overlay"),
-        };
+        let structured = AvailableOverlay::structured(
+            "org".to_string(),
+            "repo".to_string(),
+            "overlay".to_string(),
+            false,
+        );
         assert_eq!(structured.to_string(), "org/repo/overlay");
     }
 
@@ -2169,7 +2179,7 @@ mod tests {
 
         let overlays = list_overlays_in_dir(base).unwrap();
         assert_eq!(overlays.len(), 2);
-        assert!(overlays.iter().all(|o| !o.flat));
+        assert!(overlays.iter().all(|o| !o.is_flat()));
 
         let names: Vec<String> = overlays
             .iter()
@@ -2240,15 +2250,6 @@ mod tests {
 
         let commit = manager.get_source_commit("local").unwrap();
         assert_eq!(commit, "local");
-    }
-
-    #[test]
-    fn test_local_source_needs_clone_false() {
-        let temp = TempDir::new().unwrap();
-        let local_backend = ManagedSourceBackend::Local {
-            path: temp.path().to_path_buf(),
-        };
-        assert!(!local_backend.needs_clone());
     }
 
     #[test]
@@ -2423,7 +2424,9 @@ mod tests {
 
         let manager = SourceManager::new(sources, Some(repo_root)).unwrap();
 
-        let matches = manager.find_all_matches("org", "repo", "overlay", None);
+        let matches = manager
+            .find_all_matches("org", "repo", "overlay", None)
+            .unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0.name, "local");
         assert_eq!(matches[0].1, ResolvedVia::Direct);

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -204,6 +204,10 @@ impl SourceManager {
                     if manager.needs_clone() {
                         continue;
                     }
+                    // Git sources require org/repo addressing; flat lookup is local-only.
+                    if org.is_empty() || repo.is_empty() {
+                        continue;
+                    }
                     if let Some((path, resolved_via)) =
                         manager.find_overlay_path_with_fallback(org, repo, name, upstream)?
                     {
@@ -1217,6 +1221,36 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("path traversal"));
+    }
+
+    #[test]
+    fn git_source_resolution_with_empty_org_or_repo_returns_none() {
+        let temp = TempDir::new().unwrap();
+        let repo_path = temp.path().join("source");
+        fs::create_dir_all(repo_path.join(".git")).unwrap();
+        let source = Source {
+            name: "git-source".to_string(),
+            url: Some("file://dummy".to_string()),
+            path: None,
+        };
+        let manager = SourceManager {
+            sources: vec![ManagedSource {
+                source,
+                backend: ManagedSourceBackend::Git(
+                    OverlayRepoManager::new(OverlayRepoConfig {
+                        url: "file://dummy".to_string(),
+                        local_path: Some(repo_path),
+                    })
+                    .unwrap(),
+                ),
+            }],
+        };
+
+        let resolved = manager
+            .resolve("", "", "some-overlay", None, Some("git-source"))
+            .unwrap();
+
+        assert!(resolved.is_none());
     }
 
     #[test]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -555,8 +555,8 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
 
-        if is_hidden_name(&name) {
-            if is_overlay_file(&path) {
+        if name.starts_with('.') {
+            if path.is_file() {
                 has_root_files = true;
             }
             continue;
@@ -577,7 +577,7 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
                 relative_path,
                 has_config,
             ));
-        } else if is_overlay_file(&path) {
+        } else if file_type.is_file() {
             has_root_files = true;
         }
     }
@@ -595,14 +595,6 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
 
     overlays.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(overlays)
-}
-
-fn is_hidden_name(name: &str) -> bool {
-    name.starts_with('.')
-}
-
-fn is_overlay_file(path: &Path) -> bool {
-    path.is_file()
 }
 
 /// List all overlays in a directory, auto-detecting layout.

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -62,6 +62,8 @@ pub(crate) struct ResolvedOverlay {
     pub(crate) resolved_via: ResolvedVia,
     /// Current commit SHA of the source repository.
     pub(crate) commit: String,
+    /// Whether the overlay came from a flat local source layout.
+    pub(crate) flat: bool,
 }
 
 /// Manager for multiple overlay sources.
@@ -220,20 +222,39 @@ impl SourceManager {
                             source: ms.source.clone(),
                             resolved_via,
                             commit,
+                            flat: false,
                         }));
                     }
                 }
                 ManagedSourceBackend::Local { path: base_path } => {
-                    if let Some(overlay_path) = get_overlay_path_in_dir(base_path, org, repo, name)
+                    let structured_overlay_path = if org.is_empty() || repo.is_empty() {
+                        None
+                    } else {
+                        get_overlay_path_in_dir(base_path, org, repo, name)
+                    };
+                    if let Some(overlay_path) = structured_overlay_path {
+                        return Ok(Some(ResolvedOverlay {
+                            path: overlay_path,
+                            source: ms.source.clone(),
+                            resolved_via: ResolvedVia::Direct,
+                            commit: String::from("local"),
+                            flat: false,
+                        }));
+                    }
+                    if (source_filter.is_some() || org.is_empty() || repo.is_empty())
+                        && let Some(overlay_path) = get_flat_overlay_path_in_dir(base_path, name)
                     {
                         return Ok(Some(ResolvedOverlay {
                             path: overlay_path,
                             source: ms.source.clone(),
                             resolved_via: ResolvedVia::Direct,
                             commit: String::from("local"),
+                            flat: true,
                         }));
                     }
                     if let Some(upstream_info) = upstream
+                        && !org.is_empty()
+                        && !repo.is_empty()
                         && let Some(overlay_path) = get_overlay_path_in_dir(
                             base_path,
                             &upstream_info.org,
@@ -246,6 +267,7 @@ impl SourceManager {
                             source: ms.source.clone(),
                             resolved_via: ResolvedVia::Upstream,
                             commit: String::from("local"),
+                            flat: false,
                         }));
                     }
                 }
@@ -415,6 +437,21 @@ fn get_overlay_path_in_dir(base: &Path, org: &str, repo: &str, name: &str) -> Op
     }
 }
 
+fn get_flat_overlay_path_in_dir(base: &Path, name: &str) -> Option<PathBuf> {
+    let overlays = list_overlays_in_dir(base).ok()?;
+    let overlay = overlays
+        .iter()
+        .find(|overlay| overlay.flat && overlay.name.eq_ignore_ascii_case(name))?;
+    let overlay_path = base.join(overlay.relative_path());
+    let canonical_overlay = overlay_path.canonicalize().ok()?;
+    let canonical_base = base.canonicalize().ok()?;
+    if canonical_overlay.starts_with(canonical_base) && canonical_overlay.is_dir() {
+        Some(overlay_path)
+    } else {
+        None
+    }
+}
+
 /// Validate path component safety for org/repo/overlay segments.
 fn is_valid_path_component(component: &str) -> bool {
     !component.is_empty()
@@ -437,44 +474,80 @@ pub(crate) enum SourceLayout {
 /// Detect whether a directory uses structured (org/repo/name) or flat layout.
 ///
 /// A directory is considered structured if any visible top-level subdirectory
-/// contains a visible subdirectory that itself contains a visible subdirectory
-/// (i.e., 3 levels of nesting exist). Otherwise it is flat.
+/// contains a visible subdirectory that itself contains a visible overlay
+/// directory with at least one descendant file. Otherwise it is flat.
 pub(crate) fn detect_source_layout(base: &Path) -> Result<SourceLayout> {
     if !base.exists() {
         return Ok(SourceLayout::Flat);
     }
 
-    for top_entry in fs::read_dir(base)? {
-        let top_entry = top_entry?;
-        if !top_entry.path().is_dir() || top_entry.file_name().to_string_lossy().starts_with('.') {
+    for top_entry in fs::read_dir(base).with_context(|| format!("reading {}", base.display()))? {
+        let top_entry =
+            top_entry.with_context(|| format!("reading entry in {}", base.display()))?;
+        if !is_visible_candidate_dir(&top_entry)? {
             continue;
         }
 
-        // Check if this top-level dir contains a subdir that contains a subdir
-        if let Ok(mid_entries) = fs::read_dir(top_entry.path()) {
-            for mid_entry in mid_entries {
-                let Ok(mid_entry) = mid_entry else { continue };
-                if !mid_entry.path().is_dir()
-                    || mid_entry.file_name().to_string_lossy().starts_with('.')
-                {
+        let top_path = top_entry.path();
+        for mid_entry in
+            fs::read_dir(&top_path).with_context(|| format!("reading {}", top_path.display()))?
+        {
+            let mid_entry =
+                mid_entry.with_context(|| format!("reading entry in {}", top_path.display()))?;
+            if !is_visible_candidate_dir(&mid_entry)? {
+                continue;
+            }
+
+            let mid_path = mid_entry.path();
+            for leaf_entry in fs::read_dir(&mid_path)
+                .with_context(|| format!("reading {}", mid_path.display()))?
+            {
+                let leaf_entry = leaf_entry
+                    .with_context(|| format!("reading entry in {}", mid_path.display()))?;
+                if !is_visible_candidate_dir(&leaf_entry)? {
                     continue;
                 }
 
-                if let Ok(leaf_entries) = fs::read_dir(mid_entry.path()) {
-                    for leaf_entry in leaf_entries {
-                        let Ok(leaf_entry) = leaf_entry else { continue };
-                        if leaf_entry.path().is_dir()
-                            && !leaf_entry.file_name().to_string_lossy().starts_with('.')
-                        {
-                            return Ok(SourceLayout::Structured);
-                        }
-                    }
+                if is_valid_structured_overlay_leaf(&leaf_entry.path())? {
+                    return Ok(SourceLayout::Structured);
                 }
             }
         }
     }
 
     Ok(SourceLayout::Flat)
+}
+
+fn is_visible_candidate_dir(entry: &fs::DirEntry) -> Result<bool> {
+    if entry.file_name().to_string_lossy().starts_with('.') {
+        return Ok(false);
+    }
+
+    let path = entry.path();
+    let file_type = entry
+        .file_type()
+        .with_context(|| format!("reading file type for {}", path.display()))?;
+    Ok(file_type.is_dir())
+}
+
+fn is_valid_structured_overlay_leaf(path: &Path) -> Result<bool> {
+    contains_any_file(path)
+}
+
+fn contains_any_file(path: &Path) -> Result<bool> {
+    for entry in fs::read_dir(path).with_context(|| format!("reading {}", path.display()))? {
+        let entry = entry.with_context(|| format!("reading entry in {}", path.display()))?;
+        let entry_path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("reading file type for {}", entry_path.display()))?;
+
+        if file_type.is_file() || (file_type.is_dir() && contains_any_file(&entry_path)?) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// List overlays from a flat (non-nested) directory.
@@ -484,22 +557,26 @@ pub(crate) fn detect_source_layout(base: &Path) -> Result<SourceLayout> {
 /// overlay named after the directory.
 fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
     let mut overlays = Vec::new();
-    let mut has_subdirs = false;
-    let mut has_files = false;
+    let mut has_overlay_dirs = false;
+    let mut has_root_files = false;
 
     for entry in fs::read_dir(base)? {
         let entry = entry?;
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
 
-        if name.starts_with('.') {
+        if is_hidden_name(&name) {
+            if is_overlay_file(&path) {
+                has_root_files = true;
+            }
             continue;
         }
 
         if path.is_dir() {
-            has_subdirs = true;
+            has_overlay_dirs = true;
             let overlay_name = name;
             let has_config = path.join("repoverlay.ccl").exists();
+            let relative_path = PathBuf::from(&overlay_name);
 
             overlays.push(AvailableOverlay {
                 org: String::new(),
@@ -507,13 +584,14 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
                 name: overlay_name,
                 has_config,
                 flat: true,
+                relative_path,
             });
-        } else {
-            has_files = true;
+        } else if is_overlay_file(&path) {
+            has_root_files = true;
         }
     }
 
-    if !has_subdirs && has_files {
+    if !has_overlay_dirs && has_root_files {
         // The directory itself is a single overlay (has files but no subdirs)
         let dir_name = base.file_name().map_or_else(
             || "overlay".to_string(),
@@ -527,11 +605,20 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
             name: dir_name,
             has_config,
             flat: true,
+            relative_path: PathBuf::new(),
         });
     }
 
     overlays.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(overlays)
+}
+
+fn is_hidden_name(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+fn is_overlay_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 /// List all overlays in a directory, auto-detecting layout.
@@ -565,7 +652,7 @@ fn list_overlays_in_structured_dir(base: &Path) -> Result<Vec<AvailableOverlay>>
         let org_entry = org_entry?;
         let org_path = org_entry.path();
 
-        if !org_path.is_dir() || org_entry.file_name().to_string_lossy().starts_with('.') {
+        if !is_visible_candidate_dir(&org_entry)? {
             continue;
         }
 
@@ -575,7 +662,7 @@ fn list_overlays_in_structured_dir(base: &Path) -> Result<Vec<AvailableOverlay>>
             let repo_entry = repo_entry?;
             let repo_path = repo_entry.path();
 
-            if !repo_path.is_dir() || repo_entry.file_name().to_string_lossy().starts_with('.') {
+            if !is_visible_candidate_dir(&repo_entry)? {
                 continue;
             }
 
@@ -585,14 +672,17 @@ fn list_overlays_in_structured_dir(base: &Path) -> Result<Vec<AvailableOverlay>>
                 let overlay_entry = overlay_entry?;
                 let overlay_path = overlay_entry.path();
 
-                if !overlay_path.is_dir()
-                    || overlay_entry.file_name().to_string_lossy().starts_with('.')
+                if !is_visible_candidate_dir(&overlay_entry)?
+                    || !is_valid_structured_overlay_leaf(&overlay_path)?
                 {
                     continue;
                 }
 
                 let overlay_name = overlay_entry.file_name().to_string_lossy().to_string();
                 let has_config = overlay_path.join("repoverlay.ccl").exists();
+                let relative_path = PathBuf::from(&org_name)
+                    .join(&repo_name)
+                    .join(&overlay_name);
 
                 overlays.push(AvailableOverlay {
                     org: org_name.clone(),
@@ -600,6 +690,7 @@ fn list_overlays_in_structured_dir(base: &Path) -> Result<Vec<AvailableOverlay>>
                     name: overlay_name,
                     has_config,
                     flat: false,
+                    relative_path,
                 });
             }
         }
@@ -1569,6 +1660,59 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_flat_local_source_subdirectory_overlay() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path();
+        let local_source = repo_root.join("overlays");
+        let overlay = local_source.join("config-a");
+        fs::create_dir_all(&overlay).unwrap();
+        fs::write(overlay.join(".envrc"), "export A=1").unwrap();
+
+        let manager = SourceManager::new(
+            vec![Source {
+                name: "local".to_string(),
+                url: None,
+                path: Some(PathBuf::from("overlays")),
+            }],
+            Some(repo_root),
+        )
+        .unwrap();
+
+        let resolved = manager
+            .resolve("", "", "config-a", None, Some("local"))
+            .unwrap();
+
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().path, overlay);
+    }
+
+    #[test]
+    fn test_resolve_flat_local_source_root_overlay() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path();
+        let local_source = repo_root.join("my-overlay");
+        fs::create_dir_all(&local_source).unwrap();
+        fs::write(local_source.join(".envrc"), "export ROOT=1").unwrap();
+
+        let manager = SourceManager::new(
+            vec![Source {
+                name: "local".to_string(),
+                url: None,
+                path: Some(PathBuf::from("my-overlay")),
+            }],
+            Some(repo_root),
+        )
+        .unwrap();
+
+        let resolved = manager
+            .resolve("", "", "my-overlay", None, Some("local"))
+            .unwrap();
+
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().path, local_source);
+    }
+
+    #[test]
     fn test_local_source_with_upstream_fallback() {
         let temp = TempDir::new().unwrap();
         let repo_root = temp.path();
@@ -1746,6 +1890,61 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_structured_requires_leaf_overlay_files() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        fs::create_dir_all(base.join("org").join("repo").join("empty-overlay")).unwrap();
+
+        let layout = detect_source_layout(base).unwrap();
+
+        assert_eq!(layout, SourceLayout::Flat);
+    }
+
+    #[test]
+    fn test_detect_structured_allows_dotfile_overlay_files() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        let overlay = base.join("org").join("repo").join("overlay");
+        fs::create_dir_all(&overlay).unwrap();
+        fs::write(overlay.join(".envrc"), "export FOO=bar").unwrap();
+
+        let layout = detect_source_layout(base).unwrap();
+
+        assert_eq!(layout, SourceLayout::Structured);
+    }
+
+    #[test]
+    fn test_detect_structured_allows_nested_only_overlay_files() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        let workflow_dir = base
+            .join("org")
+            .join("repo")
+            .join("overlay")
+            .join(".github")
+            .join("workflows");
+        fs::create_dir_all(&workflow_dir).unwrap();
+        fs::write(workflow_dir.join("ci.yml"), "name: ci").unwrap();
+
+        let layout = detect_source_layout(base).unwrap();
+
+        assert_eq!(layout, SourceLayout::Structured);
+    }
+
+    #[test]
+    fn test_list_structured_dir_omits_empty_overlay_leaves() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        create_local_source_dir(base, &[("org", "repo", "populated")]);
+        fs::create_dir_all(base.join("org").join("repo").join("empty")).unwrap();
+
+        let overlays = list_overlays_in_dir(base).unwrap();
+
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].name, "populated");
+    }
+
+    #[test]
     fn test_detect_flat_layout_with_subdirs() {
         let temp = TempDir::new().unwrap();
         let base = temp.path();
@@ -1843,6 +2042,48 @@ mod tests {
     }
 
     #[test]
+    fn test_flat_root_overlay_relative_path_is_empty() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        fs::write(base.join(".envrc"), "export FOO=bar").unwrap();
+
+        let overlays = list_overlays_in_dir(base).unwrap();
+
+        assert_eq!(overlays.len(), 1);
+        assert!(overlays[0].flat);
+        assert_eq!(overlays[0].relative_path(), PathBuf::new());
+    }
+
+    #[test]
+    fn test_list_flat_dir_dotfile_only_single_overlay() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        fs::write(base.join(".envrc"), "export FOO=bar").unwrap();
+
+        let overlays = list_overlays_in_dir(base).unwrap();
+
+        assert_eq!(overlays.len(), 1);
+        assert!(overlays[0].flat);
+        assert_eq!(overlays[0].relative_path(), PathBuf::new());
+    }
+
+    #[test]
+    fn test_flat_dir_with_subdirs_ignores_root_files_for_discovery() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        fs::write(base.join(".envrc"), "root file ignored for discovery").unwrap();
+        let overlay_a = base.join("config-a");
+        fs::create_dir_all(&overlay_a).unwrap();
+        fs::write(overlay_a.join(".envrc"), "export A=1").unwrap();
+
+        let overlays = list_overlays_in_dir(base).unwrap();
+
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].name, "config-a");
+        assert_eq!(overlays[0].relative_path(), Path::new("config-a"));
+    }
+
+    #[test]
     fn test_list_flat_dir_skips_hidden() {
         let temp = TempDir::new().unwrap();
         let base = temp.path();
@@ -1872,6 +2113,7 @@ mod tests {
             name: "my-config".to_string(),
             has_config: true,
             flat: true,
+            relative_path: PathBuf::from("my-config"),
         };
         assert_eq!(flat.relative_path(), Path::new("my-config"));
 
@@ -1881,6 +2123,7 @@ mod tests {
             name: "overlay".to_string(),
             has_config: false,
             flat: false,
+            relative_path: PathBuf::from("org/repo/overlay"),
         };
         assert_eq!(structured.relative_path(), Path::new("org/repo/overlay"));
     }
@@ -1895,6 +2138,7 @@ mod tests {
             name: "my-config".to_string(),
             has_config: true,
             flat: true,
+            relative_path: PathBuf::from("my-config"),
         };
         assert_eq!(flat.to_string(), "my-config");
 
@@ -1904,6 +2148,7 @@ mod tests {
             name: "overlay".to_string(),
             has_config: false,
             flat: false,
+            relative_path: PathBuf::from("org/repo/overlay"),
         };
         assert_eq!(structured.to_string(), "org/repo/overlay");
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,6 +42,9 @@ pub(crate) enum OverlaySource {
     Local {
         /// Absolute path to the overlay directory
         path: PathBuf,
+        /// Configured source name, when this local path came from a named source.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_name: Option<String>,
     },
     /// GitHub repository overlay
     GitHub {
@@ -88,7 +91,18 @@ pub(crate) enum OverlaySource {
 impl OverlaySource {
     /// Create a new local source.
     pub(crate) const fn local(path: PathBuf) -> Self {
-        Self::Local { path }
+        Self::Local {
+            path,
+            source_name: None,
+        }
+    }
+
+    /// Create a new local source with configured source provenance.
+    pub(crate) const fn configured_local(path: PathBuf, source_name: String) -> Self {
+        Self::Local {
+            path,
+            source_name: Some(source_name),
+        }
     }
 
     /// Create a new GitHub source.
@@ -171,7 +185,10 @@ impl OverlaySource {
     #[allow(dead_code)]
     pub(crate) fn display(&self) -> String {
         match self {
-            Self::Local { path } => path.display().to_string(),
+            Self::Local { path, source_name } => source_name.as_ref().map_or_else(
+                || path.display().to_string(),
+                |name| format!("{} [{name}]", path.display()),
+            ),
             Self::Library { name } => format!("{name} (library)"),
             Self::GitHub {
                 url,
@@ -231,7 +248,7 @@ impl OverlaySource {
     #[allow(dead_code)]
     pub(crate) fn local_path(&self) -> Option<&Path> {
         match self {
-            Self::Local { path } => Some(path),
+            Self::Local { path, .. } => Some(path),
             Self::Library { .. } | Self::GitHub { .. } | Self::OverlayRepo { .. } => None,
         }
     }
@@ -281,7 +298,7 @@ pub(crate) trait SourceResolver {
 impl SourceResolver for OverlaySource {
     fn resolve_local_path(&self) -> Result<PathBuf> {
         match self {
-            Self::Local { path } => Ok(path.clone()),
+            Self::Local { path, .. } => Ok(path.clone()),
             Self::Library { name } => {
                 // Library path resolution requires repo context — this is handled
                 // by the caller passing the resolved library path. Use
@@ -992,10 +1009,44 @@ mod tests {
         let deserialized: OverlaySource = sickle::from_str(&serialized).unwrap();
 
         match deserialized {
-            OverlaySource::Local { path } => {
+            OverlaySource::Local { path, source_name } => {
                 assert_eq!(path, PathBuf::from("/path/to/overlay"));
+                assert_eq!(source_name, None);
             }
             _ => panic!("Expected Local source"),
+        }
+    }
+
+    #[test]
+    fn configured_local_source_preserves_source_name_and_path() {
+        let path = PathBuf::from("/tmp/repoverlay-test/config-a");
+        let source = OverlaySource::configured_local(path.clone(), "local-flat".to_string());
+
+        assert_eq!(source.local_path(), Some(path.as_path()));
+        assert!(source.is_mutable());
+        assert!(!source.is_syncable());
+        assert!(!source.is_updatable());
+        assert_eq!(
+            source.display(),
+            "/tmp/repoverlay-test/config-a [local-flat]"
+        );
+    }
+
+    #[test]
+    fn local_source_without_source_name_deserializes_for_backwards_compatibility() {
+        let serialized = sickle::to_string(&OverlaySource::local(PathBuf::from(
+            "/tmp/repoverlay-test/config-a",
+        )))
+        .unwrap();
+
+        let source: OverlaySource = sickle::from_str(&serialized).unwrap();
+
+        match source {
+            OverlaySource::Local { path, source_name } => {
+                assert_eq!(path, PathBuf::from("/tmp/repoverlay-test/config-a"));
+                assert_eq!(source_name, None);
+            }
+            other => panic!("expected local source, got {other:?}"),
         }
     }
 
@@ -1795,6 +1846,7 @@ directories =
             "test".to_string(),
             OverlaySource::Local {
                 path: PathBuf::from("/tmp"),
+                source_name: None,
             },
         );
         state.add_file(FileEntry {
@@ -1822,6 +1874,7 @@ directories =
             "test".to_string(),
             OverlaySource::Local {
                 path: PathBuf::from("/tmp"),
+                source_name: None,
             },
         );
         let removed = state.remove_file(&PathBuf::from("nonexistent.txt"));

--- a/src/status.rs
+++ b/src/status.rs
@@ -189,7 +189,7 @@ pub(crate) fn show_single_overlay_status(target: &Path, name: &str) -> Result<()
 
     // Display source based on type
     match &state.source {
-        OverlaySource::Local { path } => {
+        OverlaySource::Local { path, .. } => {
             println!("    Source:  {}", path.display());
         }
         OverlaySource::GitHub {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -96,6 +96,31 @@ fn browse_help_shows_source_argument() {
 }
 
 #[test]
+fn browse_local_flat_dotfile_root_lists_single_overlay() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let source_dir = ctx.repo_path().join("flat-source");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(source_dir.join(".envrc"), "export FOO=bar").unwrap();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "browse",
+            "./flat-source",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+            "--no-interactive",
+        ])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(flat)"))
+        .stdout(predicate::str::contains("flat-source"));
+}
+
+#[test]
 fn browse_rejects_nonexistent_local_path_source() {
     cargo_bin_cmd!("repoverlay")
         .args(["browse", "./my-overlay"])
@@ -470,6 +495,79 @@ fn apply_respects_path_mappings() {
         !ctx.file_exists(".envrc"),
         ".envrc should not exist (was mapped)"
     );
+}
+
+#[test]
+fn apply_from_configured_local_flat_subdirectory_source() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let source_dir = ctx.repo_path().join("overlays");
+    let overlay_dir = source_dir.join("config-a");
+    fs::create_dir_all(&overlay_dir).unwrap();
+    fs::write(overlay_dir.join(".envrc"), "export A=1").unwrap();
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./overlays", "--name", "local-flat"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "config-a",
+            "--from",
+            "local-flat",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert_eq!(ctx.read_file(".envrc"), "export A=1");
+    assert!(ctx.overlay_state_exists("config-a"));
+}
+
+#[test]
+fn apply_from_configured_local_flat_root_source() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let source_dir = ctx.repo_path().join("flat-source");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(source_dir.join(".envrc"), "export ROOT=1").unwrap();
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./flat-source", "--name", "local-flat"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "apply",
+            "flat-source",
+            "--from",
+            "local-flat",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    assert!(ctx.file_exists(".envrc"));
+    assert_eq!(ctx.read_file(".envrc"), "export ROOT=1");
+    assert!(ctx.overlay_state_exists("flat-source"));
 }
 
 // ============================================================================

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -92,6 +92,10 @@ repoverlay source remove tylerbutler
 
 Sources are checked in priority order when resolving overlay references. Earlier sources have higher priority.
 
+Local directory sources may use the shared `org/repo/overlay-name/` layout or a flat
+layout. In a flat layout, each top-level directory is an overlay; if there are no
+top-level overlay directories, the source directory itself is treated as one overlay.
+
 ## Conflict handling
 
 If an overlay file conflicts with an existing file in the repo, repoverlay fails by default. You can control this behavior:


### PR DESCRIPTION
## Summary

- Support flat local overlay sources in apply and browse flows.
- Preserve configured local source provenance for state and display.
- Harden source lookup and browse path resolution so unexpected errors surface and symlink escapes are rejected.

## Testing

- `just format && just check`
