### PR TITLE
docs: refresh 1.0 readiness docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "fff": {
+      "type": "stdio",
+      "command": "fff-mcp",
+      "args": []
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Important
+
+- Use the fff MCP tools for all file search operations instead of default tools.
+
 ## Quick Reference
 
 - **Development guide**: [DEV.md](DEV.md) - build commands, testing, CI, release process

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,9 @@ repoverlay is a CLI tool that overlays config files into git repositories withou
 ```
 src/
 ├── main.rs         # CLI entry point (minimal - delegates to lib)
-├── cli.rs          # CLI command definitions and argument parsing (clap)
+├── cli/
+│   ├── mod.rs      # CLI command definitions, argument parsing, and dispatch (clap)
+│   └── commands/   # Command-specific handlers for browse/cache/create/edit/etc.
 ├── lib.rs          # Core library with apply/remove/status/restore/update operations
 ├── state.rs        # State persistence (in-repo and external backup)
 ├── github.rs       # GitHub URL parsing and source resolution
@@ -33,7 +35,10 @@ tests/
 
 - **main.rs** - Minimal CLI entry point. Initializes logging and delegates to `lib::run()`.
 
-- **cli.rs** - CLI command definitions using clap derive macros. Defines all subcommands, arguments, and flags.
+- **cli/** - CLI command definitions using clap derive macros. `mod.rs` defines
+  top-level commands, arguments, flags, and dispatch; `commands/` contains
+  command-specific handlers for browse, cache, create, edit, library, move,
+  source, and sync workflows.
 
 - **lib.rs** - Core operations: `apply_overlay`, `remove_overlay`, `show_status`, `restore_overlays`, `update_overlays`, `create_overlay`, `switch_overlay`. Also handles git exclude file management.
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ Overlay config files into git repositories without committing them. Files are sy
 | Restore after git clean | `repoverlay restore` |
 | Create overlay | `repoverlay create <name>` |
 | Create local overlay | `repoverlay create --output <path>` |
-| Edit overlay | `repoverlay edit <name> --add <files>` |
+| Edit overlay | `repoverlay edit add <name> <files>` |
 | Sync changes back | `repoverlay sync <name>` |
 | Switch overlays | `repoverlay switch <source>` |
+| Move overlay source | `repoverlay move <name> --to <destination>` |
 | Manage sources | `repoverlay source add/list/remove` |
+| Manage cache | `repoverlay cache list/remove/path` |
+| Manage in-repo library | `repoverlay library list/import/export/remove` |
 | Shell completions | `repoverlay completions <shell>` |
 
 ## Concepts
@@ -89,7 +92,7 @@ repoverlay apply https://github.com/owner/repo
 repoverlay remove my-overlay
 ```
 
-For the full command reference with all options and flags, see [docs/cli-reference.md](docs/cli-reference.md).
+For the full command reference with all options and flags, see the [CLI reference](https://repoverlay.tylerbutler.com/cli-reference/).
 
 ## Overlay Configuration
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -211,6 +211,9 @@ Examples: repoverlay move my-overlay --to library repoverlay move my-overlay --t
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 * `--force` — Overwrite if destination already exists
 * `--name <NAME>` — Rename the overlay at the destination
+* `--target-repo <TARGET_REPO>` — Override the target repository (org/repo format, e.g. acme/my-app)
+
+   Used when moving to a named source and the git origin remote cannot be parsed.
 * `--dry-run` — Show what would happen without making changes
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! repoverlay - Overlay config files into git repositories without committing them.
 //!
-//! This is a CLI tool. There is no public library API.
+//! This is a CLI-first crate. The only supported library entry point is [`run`].
 
 mod cache;
 mod cli;

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -8,13 +8,13 @@ This guide covers the different ways to apply overlays to a git repository.
 
 ## Basic usage
 
-The simplest way to get started is to apply from a GitHub username. repoverlay fetches the available overlays and lets you pick interactively:
+The simplest way to get started is to browse overlays from a GitHub username. repoverlay fetches the available overlays and lets you pick interactively:
 
 ```bash
-repoverlay apply tylerbutler
+repoverlay browse tylerbutler
 ```
 
-You can also apply from a local directory or a full GitHub URL:
+For scripting or power-user workflows, use `apply` to apply a specific local directory, GitHub URL, or configured overlay reference directly:
 
 ```bash
 # Local directory
@@ -26,7 +26,7 @@ repoverlay apply https://github.com/owner/repo
 
 ## Where overlays come from
 
-repoverlay supports several source types. It determines the type automatically from what you pass to `apply`:
+repoverlay supports several source types. It determines the type automatically from what you pass to `browse` or `apply`:
 
 - Strings starting with `https://github.com/` are treated as **GitHub URLs**
 - Strings that look like filesystem paths (`./`, `/`, `~/`) are treated as **local directories**
@@ -37,7 +37,7 @@ repoverlay supports several source types. It determines the type automatically f
 ### GitHub usernames
 
 ```bash
-repoverlay apply tylerbutler
+repoverlay browse tylerbutler
 ```
 
 This fetches a default overlay repository for that user, shows available overlays filtered to your current repo, and lets you pick from an interactive list. The first time you use a source, repoverlay will ask if you want to save it for future use.

--- a/website/src/content/docs/guides/managing.md
+++ b/website/src/content/docs/guides/managing.md
@@ -29,8 +29,8 @@ The `edit` command lets you add or remove files from an applied overlay.
 ### Add files
 
 ```bash
-repoverlay edit my-overlay --add newfile.txt
-repoverlay edit my-overlay --add file1.txt --add file2.txt
+repoverlay edit add my-overlay newfile.txt
+repoverlay edit add my-overlay file1.txt file2.txt
 ```
 
 This copies the files to the overlay source, replaces the originals with symlinks, and updates the overlay state.
@@ -38,7 +38,7 @@ This copies the files to the overlay source, replaces the originals with symlink
 ### Remove files
 
 ```bash
-repoverlay edit my-overlay --remove oldfile.txt
+repoverlay edit remove my-overlay oldfile.txt
 ```
 
 ### Interactive re-selection
@@ -52,7 +52,7 @@ repoverlay edit my-overlay --interactive
 ### Preview changes
 
 ```bash
-repoverlay edit my-overlay --add new.txt --dry-run
+repoverlay edit add my-overlay new.txt --dry-run
 ```
 
 ## Syncing changes back

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -17,8 +17,8 @@ hero:
       variant: secondary
 banner:
   content: |
-    repoverlay 0.12.0 is out now!
-    <a href="https://github.com/tylerbutler/repoverlay/releases/tag/v0.12.0">See the release notes</a>.
+    repoverlay 0.14.2 is out now!
+    <a href="https://github.com/tylerbutler/repoverlay/releases/tag/v0.14.2">See the release notes</a>.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -31,12 +31,12 @@ Get up and running with repoverlay in under two minutes.
 
    You should see: `No overlays applied.`
 
-3. **Apply an overlay**
+3. **Browse and apply an overlay**
 
-   Apply an overlay from a shared source — this will show you available overlays and let you pick:
+   Browse overlays from a shared source — this will show you available overlays and let you pick:
 
    ```bash
-   repoverlay apply tylerbutler
+   repoverlay browse tylerbutler
    ```
 
    Select an overlay from the interactive list. repoverlay will ask if you want to save the source for future use.


### PR DESCRIPTION
## Summary
- regenerate the CLI reference so `move --target-repo` is documented
- refresh README, website quick-start/applying/managing docs, Rustdoc wording, and architecture docs
- rename `AGENTS.md`
- add `.mcp.json`

## Validation
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --quiet`
- `cargo run --quiet -- --markdown-help > /tmp/repoverlay-cli-reference.md && diff -u docs/cli-reference.md /tmp/repoverlay-cli-reference.md`
- `cd website && pnpm run check:astro`
- `cargo fmt --all -- --check`

Closes #326
Closes #335
Closes #336
Closes #338
Closes #340
Closes #341
Closes #342
Refs #329