### PR TITLE
test: fix six macOS-only path canonicalization test failures

### DIFF
--- a/src/cli/commands/browse.rs
+++ b/src/cli/commands/browse.rs
@@ -583,9 +583,12 @@ mod tests {
 
         let resolved = resolve_local_browse_source(source.path(), &overlay).unwrap();
 
-        assert_eq!(resolved.path, source.path().join("config-a"));
+        let expected = source.path().join("config-a").canonicalize().unwrap();
+        assert_eq!(resolved.path.canonicalize().unwrap(), expected);
         match resolved.source_info {
-            OverlaySource::Local { path, .. } => assert_eq!(path, source.path().join("config-a")),
+            OverlaySource::Local { path, .. } => {
+                assert_eq!(path.canonicalize().unwrap(), expected);
+            }
             other => panic!("expected local source, got {other:?}"),
         }
     }
@@ -618,10 +621,16 @@ mod tests {
             resolve_configured_browse_source(source.path(), &overlay, "local", "local-flat", true)
                 .unwrap();
 
-        assert_eq!(resolved.path, source.path().join("config-a"));
+        assert_eq!(
+            resolved.path.canonicalize().unwrap(),
+            source.path().join("config-a").canonicalize().unwrap()
+        );
         match resolved.source_info {
             OverlaySource::Local { path, source_name } => {
-                assert_eq!(path, source.path().join("config-a"));
+                assert_eq!(
+                    path.canonicalize().unwrap(),
+                    source.path().join("config-a").canonicalize().unwrap()
+                );
                 assert_eq!(source_name.as_deref(), Some("local-flat"));
             }
             other => panic!("expected local source, got {other:?}"),
@@ -638,7 +647,14 @@ mod tests {
             resolve_configured_browse_source(source.path(), &overlay, "abc123", "shared", false)
                 .unwrap();
 
-        assert_eq!(resolved.path, source.path().join("owner/repo/config"));
+        assert_eq!(
+            resolved.path.canonicalize().unwrap(),
+            source
+                .path()
+                .join("owner/repo/config")
+                .canonicalize()
+                .unwrap()
+        );
         match resolved.source_info {
             OverlaySource::OverlayRepo {
                 org,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1237,10 +1237,16 @@ mod tests {
 
             match resolved {
                 ResolvedSources::Single(source) => {
-                    assert_eq!(source.path, overlay);
+                    assert_eq!(
+                        source.path.canonicalize().unwrap(),
+                        overlay.canonicalize().unwrap()
+                    );
                     match source.source_info {
                         OverlaySource::Local { path, source_name } => {
-                            assert_eq!(path, overlay);
+                            assert_eq!(
+                                path.canonicalize().unwrap(),
+                                overlay.canonicalize().unwrap()
+                            );
                             assert_eq!(source_name.as_deref(), Some("local"));
                         }
                         other => panic!("expected local source, got {other:?}"),

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -1714,7 +1714,10 @@ mod tests {
             .unwrap();
 
         assert!(resolved.is_some());
-        assert_eq!(resolved.unwrap().path, overlay);
+        assert_eq!(
+            resolved.unwrap().path.canonicalize().unwrap(),
+            overlay.canonicalize().unwrap()
+        );
     }
 
     #[test]
@@ -1740,7 +1743,10 @@ mod tests {
             .unwrap();
 
         assert!(resolved.is_some());
-        assert_eq!(resolved.unwrap().path, local_source);
+        assert_eq!(
+            resolved.unwrap().path.canonicalize().unwrap(),
+            local_source.canonicalize().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Six tests fail on macOS while passing in CI (Linux-only):

```
cli::commands::browse::tests::configured_browse_flat_subdirectory_records_local_overlay_path
cli::commands::browse::tests::configured_browse_structured_preserves_overlay_repo_source
cli::commands::browse::tests::local_browse_flat_subdirectory_records_overlay_path
resolve::tests::configured_source_tests::one_part_with_source_filter_resolves_flat_local_source
sources::tests::test_resolve_flat_local_source_root_overlay
sources::tests::test_resolve_flat_local_source_subdirectory_overlay
```

## Root cause

The flat local source hardening (#317) intentionally **canonicalizes** resolved overlay paths (`SourceManager::new`, `resolve_browse_overlay_path`) to enforce the repository/source boundary. On macOS, `TempDir` paths under `/var/...` are symlinks to `/private/var/...`, so canonicalized resolved paths don't match the tests' non-canonicalized expectations. The root-overlay case additionally gains a trailing slash from `base.join("")`. CI runs only on Linux, where `/var` isn't a symlink, so this was never caught.

## Fix

Make the affected assertions canonicalization-robust by comparing `canonicalize()` results on both sides, rather than weakening the security hardening. Test-only change — no impact on the published binary, so no changelog fragment.

`just check` passes locally (format, lint, all 1171 lib tests + integration tests).