### PR TITLE
fix(ci): use nested version-files path for Cargo.toml in changie-release

### DIFF
--- a/.github/workflows/changie-release.yml
+++ b/.github/workflows/changie-release.yml
@@ -20,18 +20,11 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: tylerbutler/actions/changie-release@ee7def5950abcf0a519add705a95719ab345c05e # ratchet:tylerbutler/actions/changie-release@main
+      - uses: tylerbutler/actions/changie-release@c3a7aaef75dddeb7e07ffd49392238f996feb906 # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          # The changie-release action's bump-files only supports top-level TOML
-          # keys, but Cargo.toml's version lives under [package]. Bump it via
-          # toml-cli (tomlkit-based, comment-preserving) in post-batch-command instead.
-          post-batch-command: |
-            python3 -m pip install --quiet toml-cli
-            semver="$(changie latest)"; semver="${semver#v}"
-            toml set --toml-path Cargo.toml package.version "$semver"
-            echo "Bumped Cargo.toml to ${semver}"
+          version-files: 'Cargo.toml:package.version'
 
       # Update Cargo.lock to match the version bumped by changie-release
       - name: Update Cargo.lock

--- a/.github/workflows/changie-release.yml
+++ b/.github/workflows/changie-release.yml
@@ -24,7 +24,14 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          version-files: 'Cargo.toml:version'
+          # The changie-release action's bump-files only supports top-level TOML
+          # keys, but Cargo.toml's version lives under [package]. Bump it via
+          # toml-cli (tomlkit-based, comment-preserving) in post-batch-command instead.
+          post-batch-command: |
+            python3 -m pip install --quiet toml-cli
+            semver="$(changie latest)"; semver="${semver#v}"
+            toml set --toml-path Cargo.toml package.version "$semver"
+            echo "Bumped Cargo.toml to ${semver}"
 
       # Update Cargo.lock to match the version bumped by changie-release
       - name: Update Cargo.lock


### PR DESCRIPTION
## Problem

The `Changie Release` workflow has been failing at the **bump-files** step:

```
##[error]Failed to update Cargo.toml: "Top-level key 'version' not found"
```

(see [run 27103376117](https://github.com/tylerbutler/repoverlay/actions/runs/27103376117/job/79988021174))

### Root cause

`tylerbutler/actions/changie-release`'s `bump-files` was reimplemented in Python and only supported document-root TOML keys. `Cargo.toml`'s `version` lives under `[package]`, so `version-files: 'Cargo.toml:version'` failed. The previous `sed`-based implementation matched the column-0 line regardless of nesting, so it worked by accident until the upgrade.

## Fix

Upstream tylerbutler/actions#47 (closes #46) added **dotted TOML key path** support to `bump-files`. This PR:

- Bumps the pinned `changie-release` ref to the fix (`c3a7aae`).
- Uses the native nested syntax: `version-files: 'Cargo.toml:package.version'`.

The existing "Update Cargo.lock" step then syncs the lockfile on the release PR branch.

## Notes

- Verified the new `action.yml` documents `Cargo.toml:package.version` as a supported single-project format.
- CI-only change — no changelog fragment per repo policy.
