### PR TITLE
chore(release): add Breaking changie kind so 1.0 changes bump to 0.15.0

### DIFF
--- a/.changes/unreleased/Breaking-20260601-200118.yaml
+++ b/.changes/unreleased/Breaking-20260601-200118.yaml
@@ -1,4 +1,4 @@
-kind: Changed
+kind: Breaking
 body: |-
     Remove deprecated hidden CLI compatibility syntax
 

--- a/.changes/unreleased/Breaking-20260601-200119.yaml
+++ b/.changes/unreleased/Breaking-20260601-200119.yaml
@@ -1,4 +1,4 @@
-kind: Changed
+kind: Breaking
 body: |-
     Reject unsupported source URL schemes at parse time
 

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -17,6 +17,8 @@ body:
     block: true
     minLength: 1
 kinds:
+    - label: Breaking
+      auto: minor
     - label: Added
       auto: minor
     - label: Fixed


### PR DESCRIPTION
## Problem

The unreleased changie fragments document **breaking** changes for 1.0 (removed deprecated CLI surfaces, rejected unsupported source URL schemes), but `changie next auto` was resolving to a **patch** bump (`0.14.3`) instead of the expected `0.15.0`.

### Root cause

changie computes the bump from each fragment's `kind` `auto` level in `.changie.yaml` — it does **not** read the `**BREAKING:**` text in fragment bodies. The breaking fragments were filed under `kind: Changed` (`auto: patch`), and no kind mapped to a minor bump for breaking changes, so the whole batch capped at patch.

## Fix

- Add a `Breaking` kind with `auto: minor` as the **first** entry in `.changie.yaml`.
- Re-file the two breaking fragments (deprecated-CLI removal, URL-scheme rejection) under `kind: Breaking` and rename them to `Breaking-*.yaml`.

## Validation

```console
$ changie next auto
v0.15.0
```

The `Security`, `apply`, and `status` fragments remain patch-level; the highest level (minor) now wins, producing the intended `0.15.0` release.
