### PR TITLE
fix: cross-platform symlink in copy_tree_preserve (unblock v0.15.0 release)

### DIFF
--- a/src/profile_plan.rs
+++ b/src/profile_plan.rs
@@ -1615,8 +1615,19 @@ fn copy_tree_preserve(src: &Path, dst: &Path) -> Result<()> {
         if let Some(parent) = dst.parent() {
             fs::create_dir_all(parent)?;
         }
+        #[cfg(unix)]
         std::os::unix::fs::symlink(&link_target, dst)
             .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
+        #[cfg(windows)]
+        {
+            if fs::metadata(src).map(|m| m.is_dir()).unwrap_or(false) {
+                std::os::windows::fs::symlink_dir(&link_target, dst)
+                    .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
+            } else {
+                std::os::windows::fs::symlink_file(&link_target, dst)
+                    .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
+            }
+        }
     } else if meta.is_dir() {
         fs::create_dir_all(dst)?;
         for entry in fs::read_dir(src)? {


### PR DESCRIPTION
The v0.15.0 Release workflow failed on the `x86_64-pc-windows-msvc` build:

```
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> src/profile_plan.rs:1618:18
```

`copy_tree_preserve` called `std::os::unix::fs::symlink` unconditionally. This adds a `#[cfg(windows)]` branch using `symlink_dir`/`symlink_file`, matching the cross-platform pattern used elsewhere (e.g. `lib.rs`, `cli/commands/move.rs`).

Verified the lib now compiles for `x86_64-pc-windows-msvc`.

No changie entry: v0.15.0's changelog is already finalized and this re-ships the same version.