### PR TITLE
feat: add stop-slop skill for prose improvement

### DIFF
--- a/.agents/skills/stop-slop/CHANGELOG.md
+++ b/.agents/skills/stop-slop/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2026-01-13
+
+### Added
+
+**Phrases (references/phrases.md)**
+- Throat-clearing: "Here's what I find interesting", "Here's the problem though"
+- Performative emphasis: "creeps in", "I promise", "They exist, I promise"
+- Telling instead of showing: "This is genuinely hard", "This is what leadership actually looks like"
+
+**Structures (references/structures.md)**
+- Binary contrasts: "Not X. But Y.", "It's not this. It's that.", "stops being X and starts being Y"
+- Rhythm patterns: staccato fragmentation, dashes for dramatic pause, hedging as reassurance
+- Word patterns: absolute words (always, never, everyone, etc.), AI-overused intensifiers (deeply, truly, fundamentally, inherently, simply, literally, inevitably)
+
+## 2026-01-12
+
+- Restructured skill following Claude Code best practices (PR #1)
+- Split into SKILL.md and references/ folder
+
+## 2025-01-12
+
+- Initial release

--- a/.agents/skills/stop-slop/LICENSE
+++ b/.agents/skills/stop-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hardik Pandya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/stop-slop/README.md
+++ b/.agents/skills/stop-slop/README.md
@@ -1,0 +1,62 @@
+# Stop Slop
+
+A skill for removing AI tells from prose.
+
+<img width="3840" height="2160" alt="G-Yg4RVbIAAhVxW" src="https://github.com/user-attachments/assets/902afc15-1f40-4a9d-af24-8cd67afb8ebf" />
+
+## What this is
+
+AI writing has patterns. Predictable phrases, structures, rhythms. This skill teaches Claude (or any LLM) to catch and remove them.
+
+## Skill Structure
+
+```
+stop-slop/
+├── SKILL.md              # Core instructions
+├── references/
+│   ├── phrases.md        # Phrases to remove
+│   ├── structures.md     # Structural patterns to avoid
+│   └── examples.md       # Before/after transformations
+├── README.md
+└── LICENSE
+```
+
+## Quick start
+
+**Claude Code:** Add this folder as a skill.
+
+**Claude Projects:** Upload `SKILL.md` and reference files to project knowledge.
+
+**Custom instructions:** Copy core rules from `SKILL.md`.
+
+**API calls:** Include `SKILL.md` in your system prompt. Reference files load on demand.
+
+## What it catches
+
+**Banned phrases** - Throat-clearing openers, emphasis crutches, business jargon, all adverbs, vague declaratives, meta-commentary. See `references/phrases.md`.
+
+**Structural clichés** - Binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, narrator-from-a-distance voice, passive voice. See `references/structures.md`.
+
+**Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Author
+
+[Hardik Pandya](https://hvpandya.com)
+
+## License
+
+MIT. Use freely, share widely.

--- a/.agents/skills/stop-slop/SKILL.md
+++ b/.agents/skills/stop-slop/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: stop-slop
+description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
+---
+
+# Stop Slop
+
+Eliminate predictable AI writing patterns from prose.
+
+## Core Rules
+
+1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+
+2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+
+3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+
+4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+
+5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+
+6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
+
+7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
+
+8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
+
+## Quick Checks
+
+Before delivering prose:
+
+- Any adverbs? Kill them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with a Wh- word? Restructure it.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with punchy one-liner? Vary it.
+- Em-dash anywhere? Remove it.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
+- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+## License
+
+MIT

--- a/.agents/skills/stop-slop/references/examples.md
+++ b/.agents/skills/stop-slop/references/examples.md
@@ -1,0 +1,59 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast
+
+**Before:**
+> "Here's the thing: building products is hard. Not because the technology is complex. Because people are complex. Let that sink in."
+
+**After:**
+> "Building products is hard. Technology is manageable. People aren't."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Direct statements.
+
+---
+
+## Example 2: Filler + Unnecessary Reassurance
+
+**Before:**
+> "It turns out that most teams struggle with alignment. The uncomfortable truth is that nobody wants to admit they're confused. And that's okay."
+
+**After:**
+> "Teams struggle with alignment. Nobody admits confusion."
+
+**Changes:** Cut hedging ("most"), removed throat-clearing phrases, deleted permission-granting ending.
+
+---
+
+## Example 3: Business Jargon Stack
+
+**Before:**
+> "In today's fast-paced landscape, we need to lean into discomfort and navigate uncertainty with clarity. This matters because your competition isn't waiting."
+
+**After:**
+> "Move faster. Your competition is."
+
+**Changes:** Eliminated jargon entirely. Core message in six words.
+
+---
+
+## Example 4: Dramatic Fragmentation
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost—pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 5: Rhetorical Setup
+
+**Before:**
+> "What if I told you that the best teams don't optimize for productivity? Here's what I mean: they optimize for learning. Think about it."
+
+**After:**
+> "The best teams optimize for learning, not productivity."
+
+**Changes:** Direct claim. No rhetorical scaffolding.

--- a/.agents/skills/stop-slop/references/phrases.md
+++ b/.agents/skills/stop-slop/references/phrases.md
@@ -1,0 +1,128 @@
+# Phrases to Remove
+
+## Throat-Clearing Openers
+
+Remove these announcement phrases. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The essay should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+If a sentence says something is important/deep/structural without showing the specific thing, cut it or replace it with the specific thing.

--- a/.agents/skills/stop-slop/references/structures.md
+++ b/.agents/skills/stop-slop/references/structures.md
@@ -1,0 +1,134 @@
+# Structures to Avoid
+
+## Binary Contrasts
+
+These create false drama. State the point directly.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Instead:** State Y directly. "The problem is Y." "Y matters here." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A rhetorical striptease.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+
+**Instead:** State Z. The reader doesn't need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+
+**Instead:** Complete sentences. Trust content over presentation.
+
+## Rhetorical Setups
+
+These announce insight rather than deliver it.
+
+| Pattern | Problem |
+|---------|---------|
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Instead:** Make the point. Let readers draw conclusions.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## False Agency
+
+Giving inanimate things human verbs. Complaints don't "become" fixes. Bets don't "live or die." Decisions don't "emerge." A person does something to make those things happen. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | The complaint did nothing. Someone fixed it. |
+| "a bet lives or dies in days" | Bets don't have lifespans. Someone kills the project or ships it. |
+| "the decision emerges" | Decisions don't emerge. Someone decides. |
+| "the culture shifts" | Cultures don't shift on their own. People change behavior. |
+| "the conversation moves toward" | Conversations don't move. Someone steers. |
+| "the data tells us" | Data sits there. Someone reads it and draws a conclusion. |
+| "the market rewards" | Markets don't reward. Buyers pay for things. |
+
+**Instead:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Instead:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Instead:** Find the actor. Put them at the front of the sentence.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em-dashes | Remove. Use commas or periods. No em dashes at all. |
+| Staccato fragmentation | Don't stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -42,6 +42,12 @@
       "sourceType": "github",
       "skillPath": "skills/redesign-skill/SKILL.md",
       "computedHash": "b405eee0e0e80fc243f731d9aa368bca307e356db7e6157d27101d369dac6726"
+    },
+    "stop-slop": {
+      "source": "hardikpandya/stop-slop",
+      "sourceType": "github",
+      "skillPath": "SKILL.md",
+      "computedHash": "617bf97d33162a6bd0da4f40a97aac589de58e5a6c9cf011ed6108992210e7cb"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the [`stop-slop`](https://github.com/hardikpandya/stop-slop) agent skill, which removes common AI writing patterns ("slop") from prose during drafting, editing, and review.

## Changes

- Vendored the `stop-slop` skill under `.agents/skills/stop-slop/` (SKILL.md plus `references/` guidance on phrases, structures, and examples).
- Registered the skill in `skills-lock.json` with its source (`hardikpandya/stop-slop`) and computed hash.

## Notes

No changelog fragment included — this change is skill tooling only and does not affect the published `repoverlay` binary.
