### PR TITLE
docs: remove AI-slop patterns from README and website prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ repoverlay manages these kinds of objects:
 - **Source** — a configured location (GitHub repo or local directory) to find overlays. Lifecycle: `source add` → `source list` → `source remove`.
 - **Cache** — local clones of GitHub repos used by overlays. Managed automatically on `apply`; inspect with `cache list`, clean with `cache remove --all`.
 - **File** — an individual file within an overlay. Managed via `edit` and `sync`.
-- **Cache** — local clones of GitHub repos used by overlays. Managed automatically on `apply`; inspect with `cache list`, clean with `cache remove --all`.
-- **File** — an individual file within an overlay. Managed via `edit` and `sync`.
 
 ## Installation
 

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -4,7 +4,7 @@ sidebar:
   order: 1
 ---
 
-This guide covers the different ways to apply overlays to a git repository.
+Apply overlays to a git repository from a local directory, a GitHub URL, or a configured source.
 
 ## Basic usage
 

--- a/website/src/content/docs/guides/creating.md
+++ b/website/src/content/docs/guides/creating.md
@@ -4,7 +4,7 @@ sidebar:
   order: 2
 ---
 
-This guide covers how to create overlays from existing files and share them with others.
+Package existing files into an overlay, then share it so others can apply it.
 
 ## Creating an overlay
 

--- a/website/src/content/docs/guides/how-it-works.md
+++ b/website/src/content/docs/guides/how-it-works.md
@@ -4,7 +4,7 @@ sidebar:
   order: 5
 ---
 
-This page explains the mechanics behind how repoverlay manages overlay files.
+Symlinks, git exclusions, and external backups do the work. This page covers each mechanism.
 
 ## Symlinks vs copies
 

--- a/website/src/content/docs/guides/managing.md
+++ b/website/src/content/docs/guides/managing.md
@@ -4,7 +4,7 @@ sidebar:
   order: 3
 ---
 
-This guide covers how to check, edit, update, and remove overlays after they've been applied.
+Once overlays are applied, you can check their status, edit them, update them from their source, and remove them.
 
 ## Checking status
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -61,4 +61,4 @@ Get up and running with repoverlay in under two minutes.
 
 - Learn about [applying overlays](/guides/applying/) from different sources
 - [Create and share](/guides/creating/) your own overlays
-- Understand [how it works](/guides/how-it-works/) under the hood
+- Understand [how it works](/guides/how-it-works/)


### PR DESCRIPTION
## Summary

Cleans up AI-slop writing patterns in user-facing prose (README + website docs), applying the `stop-slop` skill's conventions.

## Changes

- **README** — removed duplicated `Cache` and `File` entries in the object reference list (a real content bug, the two entries appeared twice).
- **Guide openers** — replaced throat-clearing intros ("This guide covers…", "This page explains…") with sentences that lead with substance in `applying.md`, `creating.md`, `managing.md`, and `how-it-works.md`.
- **Quick start** — cut the "under the hood" cliché from the next-steps list.

## Notes

- Docs/website-only change; no published binary impact, so no changie fragment per repo convention.
- Em-dash definition-list separators were intentionally left in place (house style, not slop).
