### PR TITLE
docs: copyedit README, architecture, and website prose (#360)d

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,7 +220,7 @@ git remote -v
 # origin    git@github.com:tylerbutler/FluidFramework.git (fetch)
 # upstream  git@github.com:microsoft/FluidFramework.git (fetch)
 
-# Apply overlay - will fallback to microsoft/FluidFramework if needed
+# Apply overlay - falls back to microsoft/FluidFramework if needed
 repoverlay apply microsoft/FluidFramework/claude-config
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Download the pre-built binaries for your platform from the [repoverlay releases]
 
 ## Usage
 
-The easiest way to get started is with `browse`, which interactively lists available overlays and lets you select which to apply:
+The easiest way to start is with `browse`, which interactively lists available overlays and lets you select which to apply:
 
 ```bash
 # Add a source, then browse and apply interactively

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -8,13 +8,13 @@ Apply overlays to a git repository from a local directory, a GitHub URL, or a co
 
 ## Basic usage
 
-The simplest way to get started is to browse overlays from a GitHub username. repoverlay fetches the available overlays and lets you pick interactively:
+The simplest way to start is to browse overlays from a GitHub username. repoverlay fetches the available overlays and lets you pick interactively:
 
 ```bash
 repoverlay browse tylerbutler
 ```
 
-For scripting or power-user workflows, use `apply` to apply a specific local directory, GitHub URL, or configured overlay reference directly:
+For scripting or power-user workflows, point `apply` at a specific local directory, GitHub URL, or configured overlay reference:
 
 ```bash
 # Local directory

--- a/website/src/content/docs/guides/how-it-works.md
+++ b/website/src/content/docs/guides/how-it-works.md
@@ -8,7 +8,7 @@ Symlinks, git exclusions, and external backups do the work. This page covers eac
 
 ## Symlinks vs copies
 
-By default, repoverlay creates **symlinks** from the target repo to the overlay source. This means changes to the source are immediately reflected in the target.
+By default, repoverlay creates **symlinks** from the target repo to the overlay source, so changes to the source appear immediately in the target.
 
 Use the `--copy` flag to copy files instead, which is useful when:
 - Symlinks aren't supported (e.g., some Docker setups or Windows without developer mode)

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -13,7 +13,7 @@ Many development workflows require configuration files that shouldn't be committ
 - **Environment files** (`.envrc`, `.env.local`) — machine-specific paths and secrets
 - **Dev tooling** (`.prettierrc`, `biome.json`) — standards you apply across multiple repos
 
-You could copy these files manually and add them to `.gitignore`, but then you have to keep them updated across dozens of repositories. And if someone runs `git clean`, they're gone.
+You could copy these files manually and add them to `.gitignore`, but then you must keep them updated across dozens of repositories — and if someone runs `git clean`, they're gone.
 
 ## How repoverlay helps
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -33,7 +33,7 @@ Get up and running with repoverlay in under two minutes.
 
 3. **Browse and apply an overlay**
 
-   Browse overlays from a shared source — this will show you available overlays and let you pick:
+   Browse overlays from a shared source. repoverlay lists what's available and lets you pick:
 
    ```bash
    repoverlay browse tylerbutler


### PR DESCRIPTION
## Summary

Copyedit pass across the README, architecture doc, and documentation website prose, applying Strunk's clarity-and-concision rules. No content or behavior changes — wording only.

## Changes

- **README.md** — "the easiest way to get started" → "to start".
- **ARCHITECTURE.md** — corrected "will fallback" (noun used as verb) → "falls back".
- **website/.../introduction.md** — joined a sentence fragment starting with "And"; "have to" → "must".
- **website/.../quick-start.mdx** — removed redundant "this will show you available overlays".
- **website/.../guides/applying.md** — "get started" → "start"; fixed "use `apply` to apply … directly" repetition.
- **website/.../guides/how-it-works.md** — replaced passive "changes … are immediately reflected" with active voice.

## Notes

Docs-only; no changelog fragment needed (does not affect the published binary).
