### PR TITLE
fix: reject escaping symlinks in overlay directories

### DIFF
--- a/.changes/unreleased/Security-20260610-125817.yaml
+++ b/.changes/unreleased/Security-20260610-125817.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: |-
+    Reject overlay directories containing symlinks that escape the overlay
+
+    In symlink mode, a directory declared in an overlay is linked into the target repo as-is, so a malicious overlay could embed a symlink exposing arbitrary host paths (for example `.claude/evil -> ~/.ssh`) through the target repository. Directories are now vetted before anything is applied: applying fails with a "Symlink escape detected" error and the target repo is left untouched. Symlinks that stay within the overlay directory continue to work. Copy mode already had equivalent protection.
+time: 2026-06-10T12:58:17-07:00

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,6 +26,10 @@ This document contains the help content for the `repoverlay` command-line progra
 * [`repoverlay source add`↴](#repoverlay-source-add)
 * [`repoverlay source list`↴](#repoverlay-source-list)
 * [`repoverlay source remove`↴](#repoverlay-source-remove)
+* [`repoverlay marketplace`↴](#repoverlay-marketplace)
+* [`repoverlay marketplace add`↴](#repoverlay-marketplace-add)
+* [`repoverlay marketplace list`↴](#repoverlay-marketplace-list)
+* [`repoverlay marketplace remove`↴](#repoverlay-marketplace-remove)
 * [`repoverlay library`↴](#repoverlay-library)
 * [`repoverlay library list`↴](#repoverlay-library-list)
 * [`repoverlay library import`↴](#repoverlay-library-import)
@@ -54,6 +58,7 @@ Overlay config files into git repositories without committing them
 * `sync` — Sync changes from an applied overlay back to the overlay repo
 * `edit` — Edit an existing applied overlay
 * `source` — Manage overlay sources (for multi-source configurations)
+* `marketplace` — Manage plugin marketplaces
 * `library` — Manage the in-repo overlay library
 * `completions` — Generate shell completions
 
@@ -457,6 +462,57 @@ Remove an overlay source
 ###### **Arguments:**
 
 * `<NAME>` — Name of the source to remove
+
+
+
+## `repoverlay marketplace`
+
+Manage plugin marketplaces
+
+**Usage:** `repoverlay marketplace <COMMAND>`
+
+###### **Subcommands:**
+
+* `add` — Register a plugin marketplace
+* `list` — List registered marketplaces
+* `remove` — Remove a registered marketplace
+
+
+
+## `repoverlay marketplace add`
+
+Register a plugin marketplace
+
+**Usage:** `repoverlay marketplace add [OPTIONS] <NAME> <URL>`
+
+###### **Arguments:**
+
+* `<NAME>` — Name for this marketplace (used in `marketplace/plugin` references)
+* `<URL>` — Marketplace git URL or GitHub shorthand (owner/repo)
+
+###### **Options:**
+
+* `--yes` — Skip the confirmation prompt
+
+
+
+## `repoverlay marketplace list`
+
+List registered marketplaces
+
+**Usage:** `repoverlay marketplace list`
+
+
+
+## `repoverlay marketplace remove`
+
+Remove a registered marketplace
+
+**Usage:** `repoverlay marketplace remove <NAME>`
+
+###### **Arguments:**
+
+* `<NAME>` — Name of the marketplace to remove
 
 
 

--- a/src/cli/commands/edit.rs
+++ b/src/cli/commands/edit.rs
@@ -643,23 +643,17 @@ pub(crate) fn add_files_to_overlay(
                 // Create symlink/copy from overlay source to target
                 match link_type {
                     LinkType::Symlink => {
-                        #[cfg(unix)]
-                        std::os::unix::fs::symlink(&overlay_file, &target_file).with_context(
-                            || {
-                                format!(
-                                    "Failed to create directory symlink: {}",
-                                    target_file.display()
-                                )
-                            },
-                        )?;
-                        #[cfg(windows)]
-                        std::os::windows::fs::symlink_dir(&overlay_file, &target_file)
-                            .with_context(|| {
-                                format!(
-                                    "Failed to create directory symlink: {}",
-                                    target_file.display()
-                                )
-                            })?;
+                        crate::fs_util::create_symlink(
+                            &overlay_file,
+                            &target_file,
+                            crate::fs_util::SymlinkKind::Dir,
+                        )
+                        .with_context(|| {
+                            format!(
+                                "Failed to create directory symlink: {}",
+                                target_file.display()
+                            )
+                        })?;
                     }
                     LinkType::Copy | LinkType::Merged => {
                         fs::create_dir_all(&target_file).with_context(|| {
@@ -704,15 +698,14 @@ pub(crate) fn add_files_to_overlay(
                 // Create symlink/copy from overlay source to target
                 match link_type {
                     LinkType::Symlink => {
-                        #[cfg(unix)]
-                        std::os::unix::fs::symlink(&overlay_file, &target_file).with_context(
-                            || format!("Failed to create symlink: {}", target_file.display()),
-                        )?;
-                        #[cfg(windows)]
-                        std::os::windows::fs::symlink_file(&overlay_file, &target_file)
-                            .with_context(|| {
-                                format!("Failed to create symlink: {}", target_file.display())
-                            })?;
+                        crate::fs_util::create_symlink(
+                            &overlay_file,
+                            &target_file,
+                            crate::fs_util::SymlinkKind::File,
+                        )
+                        .with_context(|| {
+                            format!("Failed to create symlink: {}", target_file.display())
+                        })?;
                     }
                     LinkType::Copy | LinkType::Merged => {
                         fs::copy(&overlay_file, &target_file).with_context(|| {

--- a/src/cli/commands/move.rs
+++ b/src/cli/commands/move.rs
@@ -153,28 +153,12 @@ pub(crate) fn handle_move_command(
         }
 
         // Create new symlink
-        match entry.entry_type {
-            EntryType::File => {
-                #[cfg(unix)]
-                std::os::unix::fs::symlink(&new_link_target, &symlink_path).with_context(|| {
-                    format!("Failed to create symlink: {}", symlink_path.display())
-                })?;
-                #[cfg(windows)]
-                std::os::windows::fs::symlink_file(&new_link_target, &symlink_path).with_context(
-                    || format!("Failed to create symlink: {}", symlink_path.display()),
-                )?;
-            }
-            EntryType::Directory => {
-                #[cfg(unix)]
-                std::os::unix::fs::symlink(&new_link_target, &symlink_path).with_context(|| {
-                    format!("Failed to create symlink: {}", symlink_path.display())
-                })?;
-                #[cfg(windows)]
-                std::os::windows::fs::symlink_dir(&new_link_target, &symlink_path).with_context(
-                    || format!("Failed to create symlink: {}", symlink_path.display()),
-                )?;
-            }
-        }
+        let kind = match entry.entry_type {
+            EntryType::File => crate::fs_util::SymlinkKind::File,
+            EntryType::Directory => crate::fs_util::SymlinkKind::Dir,
+        };
+        crate::fs_util::create_symlink(&new_link_target, &symlink_path, kind)
+            .with_context(|| format!("Failed to create symlink: {}", symlink_path.display()))?;
 
         relinked += 1;
     }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -7,6 +7,38 @@ use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
 
+/// The kind of filesystem entry a symlink points to.
+///
+/// Only meaningful on Windows, where file and directory symlinks are distinct
+/// system objects; on Unix the distinction is ignored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SymlinkKind {
+    File,
+    Dir,
+}
+
+/// Create a symlink at `link` pointing to `original`, cross-platform.
+///
+/// Returns the raw `io::Result` so call sites can attach their own context.
+pub(crate) fn create_symlink(
+    original: &Path,
+    link: &Path,
+    kind: SymlinkKind,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let _ = kind;
+        std::os::unix::fs::symlink(original, link)
+    }
+    #[cfg(windows)]
+    {
+        match kind {
+            SymlinkKind::File => std::os::windows::fs::symlink_file(original, link),
+            SymlinkKind::Dir => std::os::windows::fs::symlink_dir(original, link),
+        }
+    }
+}
+
 /// Write content to a file atomically using write-then-rename.
 ///
 /// Creates a temporary file in the same directory as the target path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,6 +556,19 @@ pub(crate) fn apply_resolved_overlay(
             continue;
         }
 
+        // In symlink mode the whole directory is exposed as-is, so embedded
+        // symlinks must not escape the overlay (copy mode checks during copy).
+        // Vet before conflict resolution so nothing is removed for a bad overlay.
+        if link_type == LinkType::Symlink {
+            crate::overlay_repo::ensure_no_escaping_symlinks(&source_dir).with_context(|| {
+                format!(
+                    "Refusing to apply directory '{}' from overlay '{}'",
+                    dir_path.display(),
+                    overlay_name
+                )
+            })?;
+        }
+
         // Check for conflicts with existing overlays
         let dir_rel_str = dir_path.to_string_lossy().to_string();
         if let Some(conflicting_overlay) = existing_targets.get(&dir_rel_str) {
@@ -674,20 +687,13 @@ pub(crate) fn apply_resolved_overlay(
         // Create directory symlink or copy
         match link_type {
             LinkType::Symlink => {
-                #[cfg(unix)]
-                std::os::unix::fs::symlink(&source_dir, &target_dir).with_context(|| {
-                    format!(
-                        "Failed to create directory symlink: {}",
-                        target_dir.display()
-                    )
-                })?;
-                #[cfg(windows)]
-                std::os::windows::fs::symlink_dir(&source_dir, &target_dir).with_context(|| {
-                    format!(
-                        "Failed to create directory symlink: {}",
-                        target_dir.display()
-                    )
-                })?;
+                fs_util::create_symlink(&source_dir, &target_dir, fs_util::SymlinkKind::Dir)
+                    .with_context(|| {
+                        format!(
+                            "Failed to create directory symlink: {}",
+                            target_dir.display()
+                        )
+                    })?;
             }
             LinkType::Copy | LinkType::Merged => {
                 // For copy/merged mode, create the target directory and recursively copy contents
@@ -916,14 +922,10 @@ pub(crate) fn apply_resolved_overlay(
         );
         match link_type {
             LinkType::Symlink => {
-                #[cfg(unix)]
-                std::os::unix::fs::symlink(&source_file, &target_file).with_context(|| {
-                    format!("Failed to create symlink: {}", target_file.display())
-                })?;
-                #[cfg(windows)]
-                std::os::windows::fs::symlink_file(&source_file, &target_file).with_context(
-                    || format!("Failed to create symlink: {}", target_file.display()),
-                )?;
+                fs_util::create_symlink(&source_file, &target_file, fs_util::SymlinkKind::File)
+                    .with_context(|| {
+                        format!("Failed to create symlink: {}", target_file.display())
+                    })?;
             }
             LinkType::Copy => {
                 fs::copy(&source_file, &target_file)
@@ -3517,6 +3519,86 @@ mod tests {
             assert!(
                 !canonical.join("evil_link").exists(),
                 "symlink should not be copied to target"
+            );
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn directory_symlink_mode_rejects_escaping_symlink_inside_directory() {
+            let repo = create_test_repo();
+            let parent = TempDir::new().unwrap();
+            let overlay = parent.path().join("overlay");
+            let outside = parent.path().join("outside");
+            fs::create_dir_all(overlay.join(".claude")).unwrap();
+            fs::create_dir_all(&outside).unwrap();
+            fs::write(outside.join("secret.txt"), "secret").unwrap();
+
+            fs::write(overlay.join(".claude/CLAUDE.md"), "instructions").unwrap();
+            // Malicious symlink inside the declared directory escaping the overlay
+            std::os::unix::fs::symlink(&outside, overlay.join(".claude/evil")).unwrap();
+            fs::write(
+                overlay.join(CONFIG_FILE),
+                "overlay =\n  name = test\n\ndirectories =\n  = .claude\n",
+            )
+            .unwrap();
+
+            let resolved = ResolvedSource {
+                path: overlay.clone(),
+                source_info: OverlaySource::local(overlay),
+            };
+            let canonical = repo.path().canonicalize().unwrap();
+            let result = apply_resolved_overlay(
+                &resolved,
+                &canonical,
+                false, // symlink mode: the whole directory would be linked as-is
+                None,
+                ConflictStrategy::default(),
+                false,
+            );
+            let err = result.expect_err("apply should reject directory with escaping symlink");
+            assert!(
+                err.to_string().contains("escape") || format!("{err:#}").contains("escape"),
+                "error should mention symlink escape: {err:#}"
+            );
+            assert!(
+                !canonical.join(".claude").exists(),
+                "directory must not be linked into the target"
+            );
+        }
+
+        #[test]
+        #[cfg(unix)]
+        fn directory_symlink_mode_allows_internal_symlinks() {
+            let repo = create_test_repo();
+            let overlay = TempDir::new().unwrap();
+            fs::create_dir_all(overlay.path().join(".claude")).unwrap();
+            fs::write(overlay.path().join(".claude/CLAUDE.md"), "instructions").unwrap();
+            // Relative symlink staying inside the declared directory is fine
+            std::os::unix::fs::symlink("CLAUDE.md", overlay.path().join(".claude/alias.md"))
+                .unwrap();
+            fs::write(
+                overlay.path().join(CONFIG_FILE),
+                "overlay =\n  name = test\n\ndirectories =\n  = .claude\n",
+            )
+            .unwrap();
+
+            let resolved = ResolvedSource {
+                path: overlay.path().to_path_buf(),
+                source_info: OverlaySource::local(overlay.path().to_path_buf()),
+            };
+            let canonical = repo.path().canonicalize().unwrap();
+            let result = apply_resolved_overlay(
+                &resolved,
+                &canonical,
+                false,
+                None,
+                ConflictStrategy::default(),
+                false,
+            );
+            assert!(result.is_ok(), "apply should succeed: {result:?}");
+            assert!(
+                canonical.join(".claude/CLAUDE.md").exists(),
+                "directory should be linked into the target"
             );
         }
     }

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -598,6 +598,93 @@ fn copy_dir_recursive_inner(
     Ok(())
 }
 
+/// Validate that a directory tree contains no symlinks escaping `root`.
+///
+/// Used before symlinking an overlay directory into a target repository: the
+/// directory symlink exposes the overlay's contents as-is, so an embedded
+/// symlink pointing outside the overlay would let a malicious overlay expose
+/// arbitrary host paths through the target repository. Copy mode gets the
+/// equivalent protection inside `copy_dir_recursive`.
+pub(crate) fn ensure_no_escaping_symlinks(root: &Path) -> Result<()> {
+    let canonical_root = root
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize directory: {}", root.display()))?;
+    ensure_no_escaping_symlinks_inner(&canonical_root, &canonical_root, 0)
+}
+
+fn ensure_no_escaping_symlinks_inner(
+    dir: &Path,
+    canonical_root: &Path,
+    depth: usize,
+) -> Result<()> {
+    if depth > MAX_COPY_DEPTH {
+        bail!(
+            "Maximum directory depth ({MAX_COPY_DEPTH}) exceeded scanning {}: possible circular symlinks",
+            dir.display()
+        );
+    }
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_name() == ".git" {
+            continue;
+        }
+
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("Failed to read metadata: {}", path.display()))?;
+        if metadata.file_type().is_symlink() {
+            let contained = if let Ok(canonical) = path.canonicalize() {
+                canonical.starts_with(canonical_root)
+            } else {
+                // Dangling symlink. It cannot exfiltrate data today, but it
+                // becomes live if its target is created later, so reject it
+                // unless the target stays lexically within the root.
+                let link_target = fs::read_link(&path)
+                    .with_context(|| format!("Failed to read symlink: {}", path.display()))?;
+                lexically_contained(&path, &link_target, canonical_root)
+            };
+            if !contained {
+                bail!(
+                    "Symlink escape detected: {} points outside the overlay directory",
+                    path.display()
+                );
+            }
+        } else if metadata.is_dir() {
+            ensure_no_escaping_symlinks_inner(&path, canonical_root, depth + 1)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Lexically resolve a symlink target and check it stays within `root`.
+///
+/// Used for dangling symlinks, where canonicalization is impossible. This is
+/// best-effort by nature (it cannot follow chains of dangling links), which is
+/// fine: it only ever rejects, never grants, access beyond the canonical check.
+fn lexically_contained(link_path: &Path, target: &Path, root: &Path) -> bool {
+    use std::path::Component;
+
+    let mut resolved = if target.is_absolute() {
+        PathBuf::new()
+    } else {
+        link_path.parent().unwrap_or(root).to_path_buf()
+    };
+    for component in target.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !resolved.pop() {
+                    return false;
+                }
+            }
+            other => resolved.push(other),
+        }
+    }
+    resolved.starts_with(root)
+}
+
 /// Parse an overlay reference in the format "org/repo/name".
 #[allow(dead_code)] // Kept for backward compatibility; new code uses reference::SourceReference
 pub(crate) fn parse_overlay_reference(s: &str) -> Option<(String, String, String)> {
@@ -1645,6 +1732,80 @@ mod tests {
             !dst.join("dangling.txt").exists(),
             "Dangling symlink should not be copied"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_no_escaping_symlinks_rejects_escape() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(root.join("nested")).unwrap();
+        std::os::unix::fs::symlink("/etc/hosts", root.join("nested/escape")).unwrap();
+
+        let result = ensure_no_escaping_symlinks(&root);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Symlink escape detected")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_no_escaping_symlinks_allows_internal() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(root.join("subdir")).unwrap();
+        fs::write(root.join("subdir/target.txt"), "content").unwrap();
+        std::os::unix::fs::symlink("subdir/target.txt", root.join("link.txt")).unwrap();
+
+        assert!(ensure_no_escaping_symlinks(&root).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_no_escaping_symlinks_allows_dangling_internal() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        // Dangling but lexically inside the root: harmless even if created later
+        std::os::unix::fs::symlink("not-yet-created.txt", root.join("dangling")).unwrap();
+
+        assert!(ensure_no_escaping_symlinks(&root).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_no_escaping_symlinks_rejects_dangling_escape() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        // Dangling relative link that would resolve outside the root if its
+        // target is ever created
+        std::os::unix::fs::symlink("../outside/secret.txt", root.join("dangling")).unwrap();
+
+        let result = ensure_no_escaping_symlinks(&root);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Symlink escape detected")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_no_escaping_symlinks_rejects_dangling_absolute() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        std::os::unix::fs::symlink("/nonexistent/path/secret", root.join("dangling")).unwrap();
+
+        let result = ensure_no_escaping_symlinks(&root);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/profile_plan.rs
+++ b/src/profile_plan.rs
@@ -1615,19 +1615,13 @@ fn copy_tree_preserve(src: &Path, dst: &Path) -> Result<()> {
         if let Some(parent) = dst.parent() {
             fs::create_dir_all(parent)?;
         }
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&link_target, dst)
+        let kind = if fs::metadata(src).map(|m| m.is_dir()).unwrap_or(false) {
+            crate::fs_util::SymlinkKind::Dir
+        } else {
+            crate::fs_util::SymlinkKind::File
+        };
+        crate::fs_util::create_symlink(&link_target, dst, kind)
             .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
-        #[cfg(windows)]
-        {
-            if fs::metadata(src).map(|m| m.is_dir()).unwrap_or(false) {
-                std::os::windows::fs::symlink_dir(&link_target, dst)
-                    .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
-            } else {
-                std::os::windows::fs::symlink_file(&link_target, dst)
-                    .with_context(|| format!("Failed to recreate symlink {}", dst.display()))?;
-            }
-        }
     } else if meta.is_dir() {
         fs::create_dir_all(dst)?;
         for entry in fs::read_dir(src)? {

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -187,5 +187,5 @@ Want to see what overlays are available without applying anything? Use `repoverl
 repoverlay browse tylerbutler
 ```
 
-This fetches and lists available overlays from the source. You can still select and apply from the interactive list, but the source is not saved to your configuration.
+This fetches and lists available overlays from the source. You can still select and apply from the interactive list. As with `apply`, the first time you use a source repoverlay asks whether to save it for future use.
 :::

--- a/website/src/content/docs/guides/creating.md
+++ b/website/src/content/docs/guides/creating.md
@@ -136,9 +136,15 @@ Others can then apply your overlays using your GitHub username:
 ```bash
 # Interactive selection
 repoverlay apply tylerbutler
+```
 
-# Direct reference
-repoverlay apply tylerbutler/my-overlays/ai-config
+Direct three-part references use the *target* repository's org and repo plus the overlay name (`<target-org>/<target-repo>/<overlay-name>`), and resolve against configured sources — so consumers add your overlay repository as a source first:
+
+```bash
+repoverlay source add tylerbutler/my-overlays
+
+# Applies the ai-config overlay defined for tylerbutler/tools-monorepo
+repoverlay apply tylerbutler/tools-monorepo/ai-config
 ```
 
 Or browse without applying:


### PR DESCRIPTION
## Security fix

In symlink mode, a directory declared in an overlay's `directories` is linked into the target repo as-is. A malicious overlay could embed a symlink (e.g. `.claude/evil -> ~/.ssh`) that then resolves outside the repo through the directory link — copy mode and per-file application already rejected this, but the directory-symlink path performed no vetting.

- New `ensure_no_escaping_symlinks` in `overlay_repo.rs` walks the declared directory and rejects symlinks resolving outside it, mirroring `copy_dir_recursive`'s canonicalization check. Dangling symlinks are rejected too if their target would lexically escape (they become live if the target is later created); dangling links that stay inside the overlay remain allowed.
- `apply_resolved_overlay` runs the check before conflict resolution, so a malicious overlay fails before anything is removed from the target repo.
- Changelog fragment included (`Security` kind).

## Refactor

Cross-platform symlink creation was hand-rolled as `#[cfg(unix)]`/`#[cfg(windows)]` blocks at six sites — the duplication that caused the cf4114f bug. They're replaced by a single `fs_util::create_symlink(original, link, SymlinkKind)` that encodes the Windows file/dir distinction once.

## Docs

- Regenerated `docs/cli-reference.md`, which had gone stale before the `marketplace` commands landed (#347); they now appear in the reference and the website page that includes it.
- `creating.md`: the sharing example used an incorrect three-part reference (`<owner>/<overlay-repo>/<name>` instead of `<target-org>/<target-repo>/<name>`) and omitted the required `repoverlay source add` step.
- `applying.md`: the browse tip claimed sources are never saved when browsing; browse uses the same resolution path as apply and prompts to save on first use.