### PR TITLE
feat(profile): place Claude profile instructions in CLAUDE.md

### DIFF
--- a/.changes/unreleased/Added-20260610-140000.yaml
+++ b/.changes/unreleased/Added-20260610-140000.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |-
+    Place profile instructions for Claude in `CLAUDE.md`
+
+    Applying a profile for the Claude harness now writes its `instructions`
+    entries into a profile-keyed managed region of the repository's
+    `CLAUDE.md`, mirroring the existing Copilot `AGENTS.md` behavior.
+    Existing user content is preserved, and removing the profile strips only
+    its own region. Previously Claude applies skipped instructions with a
+    warning.
+time: 2026-06-10T14:00:00-07:00

--- a/DEV.md
+++ b/DEV.md
@@ -177,6 +177,54 @@ The GitHub App configured by `RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY` must be 
 - `tylerbutler/repoverlay` with contents/write access for release PR, tag, and release automation.
 - `tylerbutler/homebrew-tap` with contents/write access so `.github/workflows/publish-homebrew-tap.yml` can update the Homebrew formula.
 
+## Profiles Feature Status
+
+*Snapshot: 2026-06-10.*
+
+The full profiles + plugins implementation landed on `main` in #347 (squash of the `profiles` branch) and shipped in **v0.15.0**. All profile-related tests pass on `main` (46 tests via `cargo test profile`). The feature is **hidden**: the `profile`, `claude`, and `copilot` commands are declared with `hide = true` in `src/cli/mod.rs`, so they work but do not appear in `--help`. Only `marketplace` is visible.
+
+### CLI surface
+
+| Command | Visibility | Purpose |
+| --- | --- | --- |
+| `repoverlay profile list/show/apply/status/remove` | hidden | Persistent profile lifecycle (`apply`/`status`/`remove` take `--harness claude\|copilot`) |
+| `repoverlay claude --profile X [--profile Y] [-- args]` | hidden | Run Claude with profiles applied for the process lifetime (ephemeral) |
+| `repoverlay copilot --profile X [--profile Y] [-- args]` | hidden | Same for GitHub Copilot CLI |
+| `repoverlay marketplace …` | visible | Manage the plugin marketplace registry |
+| `repoverlay update` | visible | Also re-resolves managed profile plugins (full update only, not single-overlay) |
+
+### What a profile contains and how each part maps to a harness
+
+A profile (`ProfileConfig` in `src/profile.rs`) is defined under the `profiles` key of the CCL config (global `~/.config/repoverlay/config.ccl` or repo-local `.repoverlay/config.ccl`) and has four fields. Per-harness placement is owned by the applicators in `src/profile_applicators/` and the `AgentHarness` enum (single source of truth for harness paths).
+
+| Profile content | Claude mapping | Copilot mapping |
+| --- | --- | --- |
+| `description` | None — display-only in `profile list`/`show` | Same |
+| `overlays` (list of overlay refs) | `ApplyOverlay` through the regular overlay apply machinery; harness-independent | Same |
+| `instructions` (each entry exactly one of `source` file path or inline `content`) | Concatenated into a marker-delimited managed region keyed by profile name in `<repo>/CLAUDE.md`, coexisting with user content and other profiles' regions | Same, targeting `<repo>/AGENTS.md` |
+| `plugins` → bundle `skills/` | Copied to `<repo>/.claude/skills/<skill>` | Copied to `<repo>/.agents/skills/<skill>` |
+| `plugins` → bundle `agents/` | Copied to `<repo>/.claude/agents/<agent>` | Copied to `<repo>/.github/agents/<agent>` |
+| `plugins` → bundle `.mcp.json` `mcpServers` | Merged into `<repo>/.mcp.json` under `mcpServers`, `${CLAUDE_PLUGIN_ROOT}` substituted with the cached bundle dir; RFC 6901 per-pointer ownership for conflict detection and clean removal; two plugins providing the same server is an error | Same target and semantics (Copilot CLI also keys servers under `mcpServers`) |
+| `plugins` → bundle `hooks/`, `commands/` | `SkipCapability` — not decomposable | `SkipCapability` — unsupported |
+| `plugins` with `install = delegate` (or managed plugins whose source cannot be cached/introspected) | `enabledPlugins` (`"name@marketplace": true`) + `extraKnownMarketplaces` merged into `.claude/settings.json` (`scope = project`, default for persistent applies) or `.claude/settings.local.json` (`scope = local`, default for ephemeral); requires the marketplace to be registered with a URL | `SkipCapability` — delegate plugins are Claude-only |
+
+Plugin references (`PluginRef` in `src/plugin.rs`) are either marketplace refs (`marketplace/plugin` shorthand, or a table with optional `ref` pin, `install = managed|delegate`, delegate `scope`) or local paths (starting with `.` or `/`). Bundles use the Claude plugin format (`.claude-plugin/plugin.json`).
+
+Harness identity (`AgentHarness` in `src/profile_applicators/mod.rs`): stable ids `claude`/`copilot`; config homes `~/.claude` and `~/.config/github-copilot` (overridable via `REPOVERLAY_CLAUDE_HOME` / `REPOVERLAY_COPILOT_HOME`); launch programs `claude`/`copilot` (overridable via `REPOVERLAY_*_COMMAND`); removable JSON targets are `.mcp.json` plus, for Claude, `.claude/settings.json` and `.claude/settings.local.json`.
+
+### Lifecycle guarantees
+
+- Everything a profile applies lands inside the target repo's working tree, git-excluded — no user- or machine-global writes.
+- Persistent applies are transactional (rollback on failure) and recorded under `<repo>/.repoverlay/profiles/`; `repoverlay restore` rebuilds profiles after `git clean` via external snapshots.
+- Ephemeral sessions hold PID lock files with stale-lock recovery (survives `SIGKILL`/power loss), refuse to run over an already-persistent profile, and roll back all placements when the session exits or is interrupted.
+- Plugin decomposition is identical for persistent and ephemeral applies; only the delegate settings scope default differs.
+
+### Remaining work
+
+- **Hooks and commands**: plugin bundle `hooks/` and `commands/` are never decomposed for either harness.
+- **Un-hide the CLI**: `profile`, `claude`, and `copilot` are still hidden pending public announcement.
+- **Unmerged docs on the `profiles` branch**: the website profiles guide (`website/src/content/docs/guides/profiles.md`), homepage profile announcements, and the design specs/plans (`docs/superpowers/specs/2026-06-02-profiles-design.md`, `2026-06-03-plugins-design.md`, plans, and the harness-process refactor docs) exist only on the branch. The branch's source code is otherwise fully merged — `main` is *ahead* of it (the branch lacks the cf4114f cross-platform symlink fix), so only the docs need to be brought over. The unmerged guide also predates Claude instruction placement (it documents instructions as Copilot-only), so it needs updating when brought over.
+
 ## Project Structure
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed module structure and responsibilities.

--- a/src/profile_applicators/claude.rs
+++ b/src/profile_applicators/claude.rs
@@ -165,18 +165,10 @@ impl ProfileApplicator for ClaudeApplicator {
             });
         }
 
-        // Claude has no persistent profile-instruction convention yet; record
-        // each instruction as skipped rather than dropping it silently.
-        for instruction in &profile.instructions {
-            instruction.validate_exactly_one()?;
-            if let Some(source) = &instruction.source {
-                super::validate_instruction_source(Path::new(source))?;
-            }
-            actions.push(ProfileAction::SkipCapability {
-                capability: format!("instruction:{}", instruction.label()),
-                reason: "Claude persistent instruction placement is not implemented yet"
-                    .to_string(),
-            });
+        // Instructions land in a profile-keyed managed region of CLAUDE.md,
+        // mirroring Copilot's AGENTS.md region.
+        if let Some(action) = super::plan_instruction_region(profile, context)? {
+            actions.push(action);
         }
 
         let mut mcp_servers = serde_json::Map::new();
@@ -423,6 +415,65 @@ mod tests {
             ProfileAction::PlacePluginDir { target: t, .. }
                 if t.ends_with("agents/reviewer.md")
         )));
+    }
+
+    #[test]
+    fn claude_plans_instruction_write_into_claude_md() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_dir = temp.path().join("profile-assets");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(source_dir.join("claude-instructions.md"), "Be concise.").unwrap();
+
+        let profile = ProfileConfig {
+            instructions: vec![crate::profile::InstructionConfig {
+                source: Some("claude-instructions.md".to_string()),
+                content: None,
+                base_dir: None,
+            }],
+            ..ProfileConfig::default()
+        };
+        let mut context = context_for(temp.path(), &temp.path().join("claude-home"));
+        context.profile_asset_dir = source_dir;
+
+        let plan = ClaudeApplicator.plan(&profile, &context).unwrap();
+        assert!(plan.actions.iter().any(|action| matches!(
+            action,
+            ProfileAction::WriteManagedRegion { target, marker_id, .. }
+                if target.ends_with("CLAUDE.md") && marker_id == "rust-dev"
+        )));
+        assert!(
+            !plan
+                .actions
+                .iter()
+                .any(|action| matches!(action, ProfileAction::SkipCapability { .. })),
+            "instructions must be placed, not skipped"
+        );
+    }
+
+    #[test]
+    fn claude_rejects_unsafe_instruction_sources() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let context = context_for(temp.path(), &temp.path().join("claude-home"));
+
+        for source in [
+            "../secret.md".to_string(),
+            temp.path().join("secret.md").display().to_string(),
+        ] {
+            let profile = ProfileConfig {
+                instructions: vec![crate::profile::InstructionConfig {
+                    source: Some(source.clone()),
+                    content: None,
+                    base_dir: None,
+                }],
+                ..ProfileConfig::default()
+            };
+
+            let err = ClaudeApplicator.plan(&profile, &context).unwrap_err();
+            assert!(
+                err.to_string().contains("Instruction source"),
+                "unexpected error for {source}: {err}"
+            );
+        }
     }
 
     fn delegate_plugin(scope: Option<DelegateScope>) -> PluginRef {

--- a/src/profile_applicators/copilot.rs
+++ b/src/profile_applicators/copilot.rs
@@ -75,30 +75,8 @@ impl ProfileApplicator for CopilotApplicator {
             });
         }
 
-        let mut instruction_bodies = Vec::new();
-        for instruction in &profile.instructions {
-            instruction.validate_exactly_one()?;
-            if let Some(source) = &instruction.source {
-                let source_rel = Path::new(source);
-                super::validate_instruction_source(source_rel)?;
-                let base_dir = instruction
-                    .base_dir
-                    .clone()
-                    .unwrap_or_else(|| context.profile_asset_dir.clone());
-                instruction_bodies.push(crate::profile_plan::InstructionBody::File {
-                    path: base_dir.join(source_rel),
-                    base_dir,
-                });
-            } else if let Some(content) = instruction.normalized_content() {
-                instruction_bodies.push(crate::profile_plan::InstructionBody::Inline(content));
-            }
-        }
-        if !instruction_bodies.is_empty() {
-            actions.push(ProfileAction::WriteManagedRegion {
-                bodies: instruction_bodies,
-                target: context.target.join("AGENTS.md"),
-                marker_id: context.profile_name.clone(),
-            });
+        if let Some(action) = super::plan_instruction_region(profile, context)? {
+            actions.push(action);
         }
 
         // Plugin introspection: resolve each plugin, decompose its bundle into

--- a/src/profile_applicators/mod.rs
+++ b/src/profile_applicators/mod.rs
@@ -76,11 +76,11 @@ impl AgentHarness {
     }
 
     /// The single shared managed-region file this harness writes instructions
-    /// into, if any (`<repo>/AGENTS.md` for Copilot; Claude has none).
-    pub(crate) fn managed_region_path(self, repo_target: &Path) -> Option<PathBuf> {
+    /// into (`<repo>/AGENTS.md` for Copilot, `<repo>/CLAUDE.md` for Claude).
+    pub(crate) fn managed_region_path(self, repo_target: &Path) -> PathBuf {
         match self {
-            Self::Copilot => Some(repo_target.join("AGENTS.md")),
-            Self::Claude => None,
+            Self::Copilot => repo_target.join("AGENTS.md"),
+            Self::Claude => repo_target.join("CLAUDE.md"),
         }
     }
 
@@ -186,6 +186,48 @@ fn validate_instruction_source(source: &Path) -> Result<()> {
         anyhow::bail!("Instruction source '{}' must be relative", source.display());
     }
     Ok(())
+}
+
+/// Build the `WriteManagedRegion` action for a profile's instructions, if it
+/// has any.
+///
+/// Shared by every applicator: file `source` entries resolve against the
+/// entry's `base_dir` (the directory of the config file that defined it,
+/// falling back to the profile asset dir) and the region targets the harness's
+/// [`AgentHarness::managed_region_path`], keyed by the profile name.
+fn plan_instruction_region(
+    profile: &ProfileConfig,
+    context: &ProfileContext,
+) -> Result<Option<crate::profile_plan::ProfileAction>> {
+    let mut bodies = Vec::new();
+    for instruction in &profile.instructions {
+        instruction.validate_exactly_one()?;
+        if let Some(source) = &instruction.source {
+            let source_rel = Path::new(source);
+            validate_instruction_source(source_rel)?;
+            let base_dir = instruction
+                .base_dir
+                .clone()
+                .unwrap_or_else(|| context.profile_asset_dir.clone());
+            bodies.push(crate::profile_plan::InstructionBody::File {
+                path: base_dir.join(source_rel),
+                base_dir,
+            });
+        } else if let Some(content) = instruction.normalized_content() {
+            bodies.push(crate::profile_plan::InstructionBody::Inline(content));
+        }
+    }
+    if bodies.is_empty() {
+        return Ok(None);
+    }
+    let target = context.harness.managed_region_path(&context.target);
+    Ok(Some(
+        crate::profile_plan::ProfileAction::WriteManagedRegion {
+            bodies,
+            target,
+            marker_id: context.profile_name.clone(),
+        },
+    ))
 }
 
 #[derive(Debug, Clone)]

--- a/src/profile_plan.rs
+++ b/src/profile_plan.rs
@@ -66,9 +66,8 @@ pub(crate) enum ProfileAction {
     /// a native harness location by copying the tree/file.
     ///
     /// Unlike [`ProfileAction::WriteFile`], the `source` lives in the resolved
-    /// plugin bundle (the cache), not the profile asset directory. Execution,
-    /// backup, and removal of this action land in the managed-plugin lifecycle
-    /// task; until then `preflight_plan` rejects plans that contain it.
+    /// plugin bundle (the cache), not the profile asset directory. A
+    /// pre-existing target is backed up on apply and restored on removal.
     PlacePluginDir {
         source: PathBuf,
         target: PathBuf,
@@ -1179,15 +1178,14 @@ fn restore_merge_json_backup(
 }
 
 /// Validate that a managed-region target is the one allowed shared file for the
-/// harness (`<repo>/AGENTS.md` for Copilot), refusing to touch anything else.
+/// harness (`<repo>/AGENTS.md` for Copilot, `<repo>/CLAUDE.md` for Claude),
+/// refusing to touch anything else.
 fn ensure_removable_managed_region(
     harness: AgentHarness,
     repo_target: &Path,
     file: &ProfileFileEntry,
 ) -> Result<()> {
-    let allowed = harness.managed_region_path(repo_target).ok_or_else(|| {
-        anyhow::anyhow!("Managed regions are only supported for the copilot harness")
-    })?;
+    let allowed = harness.managed_region_path(repo_target);
     if file.target != allowed {
         bail!(
             "Refusing to modify managed region outside the allowed path: {}",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -383,6 +383,132 @@ profiles =
 }
 
 #[test]
+fn profile_apply_writes_claude_instruction_region_and_removes_it() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let claude_home = tempfile::TempDir::new().unwrap();
+    ctx.create_repo_file(".repoverlay/claude-instructions.md", "Use Rust 2024.");
+    ctx.write_repo_config(
+        r"
+profiles =
+  rust-dev =
+    instructions =
+      =
+        source = claude-instructions.md
+",
+    );
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "profile",
+            "apply",
+            "rust-dev",
+            "--harness",
+            "claude",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_CLAUDE_HOME", claude_home.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applied profile rust-dev"));
+
+    let claude_md = ctx.repo_path().join("CLAUDE.md");
+    let contents = fs::read_to_string(&claude_md).unwrap();
+    assert!(contents.contains("<!-- repoverlay:profile:rust-dev:begin -->"));
+    assert!(contents.contains("Use Rust 2024."));
+    assert!(contents.contains("<!-- repoverlay:profile:rust-dev:end -->"));
+    assert!(
+        ctx.repo_path()
+            .join(".repoverlay/profiles/rust-dev.claude.ccl")
+            .exists()
+    );
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "profile",
+            "remove",
+            "rust-dev",
+            "--harness",
+            "claude",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_CLAUDE_HOME", claude_home.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    assert!(
+        !claude_md.exists(),
+        "CLAUDE.md created by the profile should be removed with it"
+    );
+}
+
+#[test]
+fn profile_apply_preserves_existing_claude_md_content() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let claude_home = tempfile::TempDir::new().unwrap();
+    ctx.create_repo_file("CLAUDE.md", "# Project notes\n");
+    ctx.write_repo_config(
+        r"
+profiles =
+  docs =
+    instructions =
+      =
+        content = Be concise.
+",
+    );
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "profile",
+            "apply",
+            "docs",
+            "--harness",
+            "claude",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_CLAUDE_HOME", claude_home.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    let claude_md = ctx.repo_path().join("CLAUDE.md");
+    let contents = fs::read_to_string(&claude_md).unwrap();
+    assert!(contents.contains("# Project notes"));
+    assert!(contents.contains("Be concise."));
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "profile",
+            "remove",
+            "docs",
+            "--harness",
+            "claude",
+            "--target",
+            ctx.repo_path().to_str().unwrap(),
+        ])
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_CLAUDE_HOME", claude_home.path())
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    let contents = fs::read_to_string(&claude_md).unwrap();
+    assert!(
+        contents.contains("# Project notes") && !contents.contains("Be concise."),
+        "user content must survive removal while the region is stripped: {contents}"
+    );
+}
+
+#[test]
 fn profile_apply_excludes_repo_files_from_git() {
     let ctx = TestContext::new();
     let config_dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Profile `instructions` applied for the Claude harness now land in a profile-keyed managed region of the repo's `CLAUDE.md`, mirroring Copilot's `AGENTS.md` behavior. Previously the Claude applicator recorded every instruction as a skipped capability ("Claude persistent instruction placement is not implemented yet").

## Changes

- `AgentHarness::managed_region_path` returns `CLAUDE.md` for Claude, and drops the `Option` wrapper now that every harness has a region file (clippy `unnecessary_wraps`)
- Instruction planning (validation, `base_dir`-relative source resolution, inline-content dedent, `WriteManagedRegion` emission) is deduplicated into a shared `plan_instruction_region` helper used by both applicators
- The existing apply/remove/snapshot machinery needed no changes — transactional apply, region stripping on removal, multi-profile coexistence, and restore-after-`git clean` were already generic over the region target
- Doc-comment cleanup: `ProfileAction::PlacePluginDir` no longer claims `preflight_plan` rejects it (placement is implemented and tested); `ensure_removable_managed_region` is no longer described as Copilot-only
- DEV.md gains a "Profiles Feature Status" section recording the profile-contents-to-harness mapping, lifecycle guarantees, and remaining work

## Tests

Written first (TDD), confirmed failing before the implementation:

- `claude_plans_instruction_write_into_claude_md` / `claude_rejects_unsafe_instruction_sources` (unit, mirroring the Copilot applicator tests)
- `profile_apply_writes_claude_instruction_region_and_removes_it` (CLI: apply writes the marker-delimited region + state file; remove deletes the file it created)
- `profile_apply_preserves_existing_claude_md_content` (CLI: pre-existing `CLAUDE.md` user content survives apply and remove; only the region is stripped)

`just check` passes end-to-end (fmt, clippy pedantic/nursery, full test suite).