### PR TITLE
docs: add in-repo library guide and sync docs with current code

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -43,9 +43,7 @@ components:
     - browse
     - cache
     - create
-    - create-local
     - edit
-    - list
     - move
     - remove
     - restore

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,24 @@
 {
   "mcpServers": {
+    "context7": {
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "command": "npx"
+    },
     "fff": {
       "args": [],
       "command": "fff-mcp",
       "type": "stdio"
+    },
+    "semble": {
+      "args": [
+        "--from",
+        "semble[mcp]",
+        "semble"
+      ],
+      "command": "uvx"
     }
   }
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,25 +6,44 @@ repoverlay is a CLI tool that overlays config files into git repositories withou
 
 ```
 src/
-├── main.rs         # CLI entry point (minimal - delegates to lib)
+├── main.rs              # CLI entry point (minimal - delegates to lib)
 ├── cli/
-│   ├── mod.rs      # CLI command definitions, argument parsing, and dispatch (clap)
-│   └── commands/   # Command-specific handlers for browse/cache/create/edit/etc.
-├── lib.rs          # Core library with apply/remove/status/restore/update operations
-├── state.rs        # State persistence (in-repo and external backup)
-├── github.rs       # GitHub URL parsing and source resolution
-├── cache.rs        # GitHub repository cache management
-├── config.rs       # Global and per-repo configuration (CCL format)
-├── sources.rs      # Multi-source overlay resolution with priority ordering
-├── overlay_repo.rs # Shared overlay repository integration
-├── upstream.rs     # Upstream repository detection for fork inheritance
-├── library.rs      # In-repo overlay library management
-├── detection.rs    # File discovery for overlay creation
-├── selection.rs    # Interactive file selection UI
-├── widgets/        # Reusable ratatui UI components
-│   ├── mod.rs
+│   ├── mod.rs           # CLI command definitions, argument parsing, and dispatch (clap)
+│   └── commands/        # Handlers: browse, cache, claude, copilot, create, edit,
+│                        #   library, marketplace, move, profile, source, sync
+├── lib.rs               # Core library: apply_overlay, composition resolution, glue
+├── resolve.rs           # Source resolution (source string → local path)
+├── reference.rs         # Input reference parsing
+├── status.rs            # show_status / show_status_json
+├── remove.rs            # remove_overlay
+├── create.rs            # create_overlay and update_overlays
+├── update.rs            # CLI version string and self-update check
+├── state.rs             # State persistence (in-repo and external backup)
+├── github.rs            # GitHub URL parsing
+├── cache.rs             # GitHub repository cache management
+├── config.rs            # Global and per-repo configuration (CCL format)
+├── sources.rs           # Multi-source overlay resolution with priority ordering
+├── overlay_repo.rs      # Shared overlay repository integration
+├── upstream.rs          # Upstream repository detection for fork inheritance
+├── library.rs           # In-repo overlay library management
+├── git.rs               # Git subprocess helpers and repository inspection
+├── git_exclude.rs       # .git/info/exclude section management
+├── json_merge.rs        # JSON deep merge for --merge
+├── fuzzy.rs             # Fuzzy matching for overlay name suggestions
+├── fs_util.rs           # Filesystem utilities (atomic writes, copies)
+├── path_safety.rs       # Path safety validation (traversal protection)
+├── overlay_name.rs      # Normalized overlay name newtype
+├── detection.rs         # File discovery for overlay creation
+├── selection.rs         # Interactive file selection UI
+├── widgets/             # Reusable ratatui UI components
 │   └── multi_select_tree.rs  # Tree widget with tri-state checkboxes
-└── testutil.rs     # Test utilities (create_test_repo, create_test_overlay)
+├── profile.rs           # Profile configuration, merge rules, state metadata
+├── plugin.rs            # Plugin reference model and marketplace resolution
+├── profile_plan.rs      # Profile apply planning and transactional execution
+├── profile_applicators/ # Per-harness placement (claude.rs, copilot.rs)
+├── harness_process.rs   # Managed harness process execution (ephemeral mode)
+├── snapshots/           # insta snapshot files for unit tests
+└── testutil.rs          # Test utilities (create_test_repo, create_test_overlay)
 
 tests/
 ├── cli.rs          # CLI integration tests using assert_cmd
@@ -37,10 +56,16 @@ tests/
 
 - **cli/** - CLI command definitions using clap derive macros. `mod.rs` defines
   top-level commands, arguments, flags, and dispatch; `commands/` contains
-  command-specific handlers for browse, cache, create, edit, library, move,
-  source, and sync workflows.
+  command-specific handlers.
 
-- **lib.rs** - Core operations: `apply_overlay`, `remove_overlay`, `show_status`, `restore_overlays`, `update_overlays`, `create_overlay`, `switch_overlay`. Also handles git exclude file management.
+- **lib.rs** - Core apply machinery: `apply_overlay`, overlay composition resolution
+  (`extends`/`includes`), and shared helpers. Status, remove, create, and update
+  operations live in their own modules (`status.rs`, `remove.rs`, `create.rs`).
+
+- **resolve.rs / reference.rs** - Turn user input into something applyable:
+  `reference.rs` parses the input string (path, URL, `org/repo/name`, bare name),
+  `resolve.rs` resolves it to a local overlay directory, consulting the library,
+  configured sources, and the GitHub cache.
 
 - **selection.rs** - Interactive file selection UI. Handles checkbox-style multi-select for overlay creation.
 
@@ -55,9 +80,9 @@ tests/
 
 - **cache.rs** - GitHub repository caching. Manages cloned repos in `~/.cache/repoverlay/github/owner/repo/`. Supports shallow clones and update checking.
 
-- **config.rs** - Configuration management using CCL format. Handles global config (`~/.config/repoverlay/config.ccl`) and per-overlay config (`repoverlay.ccl`).
+- **config.rs** - Configuration management using CCL format. Handles global config (`~/.config/repoverlay/config.ccl`), per-repo config (`.repoverlay/config.ccl`), and per-overlay config (`repoverlay.ccl`).
 
-- **sources.rs** - Multi-source overlay resolution. Manages a priority-ordered list of overlay sources (configured via `repoverlay source add/remove/list`). Provides `SourceManager` for resolving overlay references across multiple sources with first-match-wins semantics.
+- **sources.rs** - Multi-source overlay resolution. Manages a priority-ordered list of overlay sources (configured via `repoverlay source add/remove/list`). Provides `SourceManager` for resolving overlay references across multiple sources with first-match-wins semantics. Configured git sources are cloned to `~/.cache/repoverlay/sources/<name>/`.
 
 - **overlay_repo.rs** - Shared overlay repository support. Allows overlays to be referenced as `org/repo/name` from a centrally managed repository. Supports fallback resolution for fork inheritance.
 
@@ -65,7 +90,24 @@ tests/
 
 - **library.rs** - In-repo overlay library management. Handles the `.repoverlay/library/` directory for storing shareable overlays within a repository. Provides path resolution (configurable via per-repo config), overlay listing, import/export/remove operations, and gitignore detection. Library overlays are auto-discovered and resolved with highest priority.
 
+- **git.rs / git_exclude.rs** - Git subprocess helpers (with Ctrl+C handling) and
+  management of named overlay sections in `.git/info/exclude`.
+
+- **json_merge.rs / fuzzy.rs / fs_util.rs / path_safety.rs / overlay_name.rs** -
+  Support modules: JSON deep merge for `--merge`, fuzzy name suggestions, atomic
+  filesystem operations, path traversal protection, and the normalized overlay
+  name newtype.
+
 - **detection.rs** - File discovery for the `create` command. Identifies AI configs, gitignored files, and untracked files that might be candidates for overlay creation.
+
+- **profile.rs / plugin.rs / profile_plan.rs / profile_applicators/ / harness_process.rs** -
+  The profile subsystem. `profile.rs` defines `ProfileConfig` (description, overlays,
+  instructions, plugins) and profile state; `plugin.rs` models plugin references and
+  resolves them from marketplaces or local paths; `profile_plan.rs` plans and executes
+  a profile apply transactionally; `profile_applicators/` owns per-harness placement
+  (Claude vs Copilot paths); `harness_process.rs` runs a harness process with
+  ephemeral profiles applied for its lifetime. See DEV.md "Profiles Feature Status"
+  for the capability matrix.
 
 - **testutil.rs** - Test utilities including `create_test_repo()` and `create_test_overlay()` helpers for setting up temporary git repositories in tests.
 
@@ -150,6 +192,29 @@ Remove all existing overlays
 Apply new overlay (atomic replacement)
 ```
 
+### Profile apply
+
+```
+Look up profile in config (repo-local .repoverlay/config.ccl over global config)
+    ↓
+Resolve plugins (PluginRef → marketplace clone or local bundle dir)
+    ↓
+Build ProfilePlan for the chosen harness (claude | copilot):
+    - overlays → regular overlay apply machinery
+    - instructions → managed region in CLAUDE.md / AGENTS.md
+    - plugin skills/agents → harness-specific directories
+    - plugin MCP servers → merged into .mcp.json
+    - delegate plugins (Claude only) → .claude/settings[.local].json
+    ↓
+Execute plan transactionally (rollback on failure)
+    ↓
+Record state under .repoverlay/profiles/ + external snapshot
+```
+
+Ephemeral mode (`repoverlay claude|copilot --profile X`) runs the same plan, holds a
+PID lock while the harness process runs, and rolls back all placements when it exits.
+See DEV.md "Profiles Feature Status" for the full per-harness capability matrix.
+
 ## State File Format
 
 Overlay state is stored in CCL format (a human-readable configuration language). Example:
@@ -157,18 +222,24 @@ Overlay state is stored in CCL format (a human-readable configuration language).
 ```
 name = my-overlay
 applied_at = 2024-01-15T10:30:00Z
-source = local|/path/to/overlay
+source =
+  type = Local
+  path = /path/to/overlay
 files =
-  source = .envrc
-  target = .envrc
-  link_type = symlink
+  =
+    source = .envrc
+    target = .envrc
+    link_type = symlink
 ```
 
-Source types are encoded as pipe-delimited strings:
-- Local: `local|/path/to/overlay`
-- Library: `library|name` (in-repo `.repoverlay/library/` overlay)
-- GitHub: `github|url|owner|repo|ref|commit|subpath|cached_at`
-- Overlay repo: `overlay_repo|org|repo|name|commit`
+The source is an internally tagged enum (`OverlaySource` in `src/state.rs`, `#[serde(tag = "type")]`): a nested block whose `type` field selects the variant, with the variant's fields alongside it. The variants and their fields:
+
+- `Local`: `path`, optional `source_name`
+- `Library`: `name` (in-repo `.repoverlay/library/` overlay)
+- `GitHub`: `url`, `owner`, `repo`, `git_ref`, `commit`, optional `subpath`, `cached_at`
+- `OverlayRepo`: `org`, `repo`, `name`, `commit`, optional `resolved_via`, optional `source_name`
+
+(`repoverlay status --json` exposes the same shape with lowercase `type` values; that JSON schema is the stable contract for scripting.)
 
 ## Git Integration
 
@@ -194,7 +265,7 @@ The `resolve_source()` function determines the overlay source type:
 1. **GitHub URL** (`https://github.com/...`) - Downloads to cache, returns cached path
 2. **Local path** (`./path` or `/path`) - Returns path directly after validation
 3. **Library overlay** (bare name) - Checks `.repoverlay/library/` first (highest priority)
-4. **Overlay repo reference** (`org/repo/name`) - Resolves from configured shared repository
+4. **Configured source reference** (`org/repo/name`) - Resolves from configured sources in priority order
 
 ## Fork Inheritance
 
@@ -287,6 +358,8 @@ GitHub repositories are cached in `~/.cache/repoverlay/github/owner/repo/`:
 - Caches are updated on `repoverlay update` or when `--ref` changes
 - Cache metadata tracks commit hash and last update time
 - `repoverlay cache` subcommands manage the cache
+
+Configured sources are cloned separately to `~/.cache/repoverlay/sources/<name>/` and refreshed when commands resolve from them. The `cache` subcommands only operate on the `github/` directory.
 
 ## Decisions
 

--- a/DEV.md
+++ b/DEV.md
@@ -122,7 +122,7 @@ Before merging a release PR, ensure:
    just change    # Runs: changie new
    ```
 
-   Select one of the configured kinds (`Added`, `Fixed`, `Performance`, `Changed`, `Reverted`, `Dependencies`, `Security`) and an appropriate component (`features`, `fixes`, `misc`, `library`, or a command name: `apply`, `browse`, `cache`, `create`, `create-local`, `edit`, `list`, `move`, `remove`, `restore`, `source`, `status`, `switch`, `sync`).
+   Select one of the configured kinds (`Breaking`, `Added`, `Fixed`, `Performance`, `Changed`, `Reverted`, `Dependencies`, `Security`) and an appropriate component (`features`, `fixes`, `misc`, `library`, or a command name: `apply`, `browse`, `cache`, `create`, `edit`, `move`, `remove`, `restore`, `source`, `status`, `switch`, `sync`, `update`).
 
    No changelog fragment is needed for CI-only/release-plumbing documentation changes that do not affect the published binary.
 
@@ -224,6 +224,10 @@ Harness identity (`AgentHarness` in `src/profile_applicators/mod.rs`): stable id
 - **Hooks and commands**: plugin bundle `hooks/` and `commands/` are never decomposed for either harness.
 - **Un-hide the CLI**: `profile`, `claude`, and `copilot` are still hidden pending public announcement.
 - **Unmerged docs on the `profiles` branch**: the website profiles guide (`website/src/content/docs/guides/profiles.md`), homepage profile announcements, and the design specs/plans (`docs/superpowers/specs/2026-06-02-profiles-design.md`, `2026-06-03-plugins-design.md`, plans, and the harness-process refactor docs) exist only on the branch. The branch's source code is otherwise fully merged — `main` is *ahead* of it (the branch lacks the cf4114f cross-platform symlink fix), so only the docs need to be brought over. The unmerged guide also predates Claude instruction placement (it documents instructions as Copilot-only), so it needs updating when brought over.
+
+## Vendored Agent Skills
+
+The repository tracks skills for AI coding agents working on this codebase: `.claude/skills/` (Claude Code) and `.agents/skills/` (other harnesses) hold vendored skill copies, and `skills-lock.json` pins each skill's upstream source and version. These are contributor tooling only — they are not part of the published binary and do not appear in user documentation.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The key distinction in repoverlay is between a **definition** (a reusable, repo-
 
 An **overlay** is a *definition*: a named bundle of config files. Nothing about an overlay is tied to a repo — `rust-base` is just "these files." It only becomes repo-associated when you `apply` it, at which point the files land in *that* repo's working tree and are excluded via `.git/info/exclude`. So "overlays are associated with a repo" is only true of the **applied instance**, not the overlay itself.
 
-A **profile** is a *recipe* one layer up: it composes overlays **and** adds AI-harness capabilities — instruction files and plugins. Plugins are the bundling unit for skills and MCP servers, in the same Claude-style format used by the Claude Code ecosystem. Like overlays, a profile is a portable definition that gets applied to a specific repo, and everything it applies lands **inside that repo's working tree** (git-excluded):
+A **profile** is a *recipe* one layer up: it composes overlays **and** adds AI-harness capabilities — instruction files and plugins. (Profiles are [experimental](#profiles-experimental).) Plugins are the bundling unit for skills and MCP servers, in the same Claude-style format used by the Claude Code ecosystem. Like overlays, a profile is a portable definition that gets applied to a specific repo, and everything it applies lands **inside that repo's working tree** (git-excluded):
 
 | | Payload | Scope of effect when applied |
 | --- | --- | --- |
@@ -51,9 +51,9 @@ In short: an **overlay** is an *ingredient* (files only), a **profile** is a *re
 repoverlay manages these kinds of objects:
 
 - **Overlay** — a reusable, repo-agnostic bundle of config files. Becomes repo-associated only when applied. Lifecycle: `create` → `apply` → `update` → `remove`.
-- **Profile** — a recipe that composes overlays with AI harness capabilities (plugins bundling skills + MCP servers, and instruction files), all placed repo-local. Applied persistently with `profile apply` or ephemerally with harness commands such as `repoverlay copilot --profile rust-dev` or `repoverlay claude --profile rust-dev`.
-- **Plugin** — a Claude-style bundle of skills and/or MCP servers. Referenced from a profile via a marketplace (`marketplace/plugin`) or a local path (a directory with a `.claude-plugin/plugin.json` manifest).
-- **Marketplace** — a named git repository registry that plugins are resolved from, cached locally like overlay sources.
+- **Profile** *(experimental)* — a recipe that composes overlays with AI harness capabilities (plugins bundling skills + MCP servers, and instruction files), all placed repo-local. Applied persistently with `profile apply` or ephemerally with harness commands such as `repoverlay copilot --profile rust-dev` or `repoverlay claude --profile rust-dev`.
+- **Plugin** *(experimental)* — a Claude-style bundle of skills and/or MCP servers. Referenced from a profile via a marketplace (`marketplace/plugin`) or a local path (a directory with a `.claude-plugin/plugin.json` manifest).
+- **Marketplace** *(experimental)* — a named git repository registry that plugins are resolved from, cached locally like overlay sources.
 - **Source** — a configured location (GitHub repo or local directory) to find overlays. Lifecycle: `source add` → `source list` → `source remove`.
 - **Cache** — local clones of GitHub repos used by overlays. Managed automatically on `apply`; inspect with `cache list`, clean with `cache remove --all`.
 - **File** — an individual file within an overlay. Managed via `edit` and `sync`.
@@ -167,7 +167,32 @@ repoverlay apply https://github.com/owner/repo
 repoverlay remove my-overlay
 ```
 
-Profiles can declare overlays and AI harness configuration:
+### Profiles (experimental)
+
+> [!WARNING]
+> Profiles, plugins, and the harness commands are **experimental**. The `profile`, `claude`, and `copilot` commands work but are hidden from `--help` and the CLI reference, and their interface may change before they are announced.
+
+Profiles can declare overlays and AI harness configuration. Define them under the `profiles` key of the global config (`~/.config/repoverlay/config.ccl`) or the repo-local config (`.repoverlay/config.ccl`):
+
+```
+profiles =
+  rust-dev =
+    description = Rust development with AI tooling
+    overlays =
+      = org/repo/rust-base
+    instructions =
+      =
+        source = instructions/rust.md
+      =
+        content = Prefer cargo nextest for running tests.
+    plugins =
+      = my-marketplace/rust-tools
+      = ./plugins/local-bundle
+```
+
+All four keys are optional. `overlays` lists overlay references applied through the normal apply machinery. Each `instructions` entry sets exactly one of `source` (a file path relative to the config file's directory) or `content` (inline text). `plugins` entries are `marketplace/plugin` references (register marketplaces with `repoverlay marketplace add <name> <url>`) or local paths to a Claude-style plugin bundle; a table form supports pinning a git `ref` and choosing `install = managed|delegate`.
+
+Inspect profiles with:
 
 ```bash
 repoverlay profile list
@@ -189,7 +214,7 @@ repoverlay copilot --profile rust-dev -- --help
 repoverlay claude --profile rust-dev
 ```
 
-Capabilities are placed repo-local: plugin skills go to `.agents/skills/` (Copilot) or `.claude/skills/` (Claude), plugin MCP servers merge into the repo's `.mcp.json`, and Copilot instruction files are written into an `AGENTS.md` managed region. Claude can also *delegate* plugin enablement to its own settings instead of placing files. A full `repoverlay update` re-resolves applied profiles' managed plugins and re-applies any whose source changed.
+Capabilities are placed repo-local: plugin skills go to `.agents/skills/` (Copilot) or `.claude/skills/` (Claude), plugin MCP servers merge into the repo's `.mcp.json`, and instruction files are written into a managed region of `AGENTS.md` (Copilot) or `CLAUDE.md` (Claude). Claude can also *delegate* plugin enablement to its own settings instead of placing files. A full `repoverlay update` re-resolves applied profiles' managed plugins and re-applies any whose source changed.
 
 For the full command reference with all options and flags, see the [CLI reference](https://repoverlay.tylerbutler.com/cli-reference/).
 
@@ -207,6 +232,7 @@ Create a `repoverlay.ccl` in your overlay directory:
 ```
 overlay =
   name = my-config
+  description = Shared editor and environment config
 
 /= Rename files when applying
 mappings =
@@ -219,9 +245,13 @@ directories =
   = scratch
 ```
 
-**`mappings`** — Rename files during apply (source = destination).
+**`overlay`** — Metadata: `name` (defaults to the directory name) and an optional `description`.
+
+**`mappings`** — Rename files during apply (source = destination). Repeat a source key to map one file to multiple destinations.
 
 **`directories`** — Directories to symlink (or copy) as a unit rather than walking individual files. Useful for directories like `.claude/` that should be managed atomically.
+
+**`extends`** / **`includes`** — Inherit all files from a parent overlay, or cherry-pick files from other overlays. Composition works between overlays in the [in-repo library](https://repoverlay.tylerbutler.com/guides/library/); see [Composing overlays](https://repoverlay.tylerbutler.com/guides/creating/#composing-overlays).
 
 Without a config file, all files are symlinked with the same relative path.
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -101,6 +101,10 @@ export default defineConfig({
 							slug: "guides/managing",
 						},
 						{
+							label: "The In-Repo Library",
+							slug: "guides/library",
+						},
+						{
 							label: "Restoring After Git Clean",
 							slug: "guides/restoring",
 						},

--- a/website/src/content/docs/guides/applying.md
+++ b/website/src/content/docs/guides/applying.md
@@ -30,7 +30,7 @@ repoverlay supports several source types. It determines the type automatically f
 
 - Strings starting with `https://github.com/` are treated as **GitHub URLs**
 - Strings that look like filesystem paths (`./`, `/`, `~/`) are treated as **local directories**
-- Three-part strings like `org/repo/name` are treated as **overlay repository references**
+- Three-part strings like `org/repo/name` are treated as **configured source references**
 - Two-part strings like `owner/repo` enter **browse mode** (interactive selection)
 - Single words like `tylerbutler` are treated as **GitHub usernames**
 
@@ -41,6 +41,8 @@ repoverlay browse tylerbutler
 ```
 
 This fetches a default overlay repository for that user, shows available overlays filtered to your current repo, and lets you pick from an interactive list. The first time you use a source, repoverlay will ask if you want to save it for future use.
+
+A bare username expands to `username/repo-overlays`. To use a different repository name, set the `REPOVERLAY_DEFAULT_REPO_NAME` environment variable — for example, `REPOVERLAY_DEFAULT_REPO_NAME=overlays` expands `tylerbutler` to `tylerbutler/overlays`.
 
 ### GitHub URLs
 
@@ -58,7 +60,7 @@ repoverlay apply https://github.com/owner/repo/tree/main/overlays/rust
 
 GitHub sources are cached locally using shallow clones. Use `repoverlay update` to pull new changes later.
 
-### Overlay repository references
+### Configured source references
 
 If you've used a source before (or added one manually), you can reference a specific overlay by its path:
 
@@ -139,6 +141,8 @@ Deep merge combines objects recursively — overlay keys are added or updated, b
 :::note
 `--merge` can be combined with `--force` or `--skip-conflicts`. When combined with `--force`, JSON files are merged while non-JSON conflicts are overwritten. When combined with `--skip-conflicts`, JSON files are merged while non-JSON conflicts are skipped.
 :::
+
+To enable merging by default, set the `REPOVERLAY_MERGE=true` environment variable. It acts as the default for the `--merge` flag everywhere the flag exists (`apply`, `switch`, `restore`, and `update`).
 
 ## Other options
 

--- a/website/src/content/docs/guides/creating.md
+++ b/website/src/content/docs/guides/creating.md
@@ -73,6 +73,7 @@ Create a `repoverlay.ccl` in the root of your overlay directory to control how f
 ```
 overlay =
   name = my-config
+  description = Shared editor and environment config
 
 /= Rename files when applying
 mappings =
@@ -85,13 +86,21 @@ directories =
   = scratch
 ```
 
-### Overlay name
+### Overlay name and description
 
-The `overlay.name` field sets the name used in `status`, `remove`, and other commands. If omitted, the directory name is used.
+The `overlay.name` field sets the name used in `status`, `remove`, and other commands. If omitted, the directory name is used. The optional `overlay.description` field documents what the overlay is for, for people reading the overlay config.
 
 ### Mappings
 
 The `mappings` section renames files during apply. Each entry maps a source filename to a destination path. This is useful when the overlay uses different filenames than the target repo expects.
+
+One source file can map to multiple destinations — repeat the key with a different destination each time:
+
+```
+mappings =
+  config.json = .vscode/settings.json
+  config.json = .zed/settings.json
+```
 
 ### Directories
 
@@ -100,6 +109,48 @@ The `directories` section lists directories to symlink (or copy) as a unit rathe
 ### Configuration format
 
 repoverlay uses [CCL (Categorical Configuration Language)](https://ccl.tylerbutler.com/) for configuration files. CCL uses `=` for key-value pairs and indentation for nesting. Lines starting with `/=` are comments.
+
+## Composing overlays
+
+Overlays in the [in-repo library](/guides/library/) can build on each other instead of duplicating files. Two keys in `repoverlay.ccl` control this:
+
+### extends
+
+Inherit every file from a single parent overlay:
+
+```
+extends =
+  overlay = base-config
+```
+
+The parent's files, mappings, and directories are all inherited. Chains are allowed (a child can extend a parent that itself extends a grandparent), and repoverlay detects cycles.
+
+### includes
+
+Cherry-pick specific files from other overlays:
+
+```
+includes =
+  =
+    overlay = tools
+    files =
+      = .editorconfig
+      = scripts/lint.sh
+```
+
+You can list several `includes` entries, and included overlays are resolved recursively — they may use `extends` or `includes` themselves.
+
+### Precedence
+
+When the same destination path comes from more than one place, the highest-precedence version wins:
+
+1. The overlay's own files
+2. Files from `extends`
+3. Files from `includes` (later entries override earlier ones)
+
+:::note
+Composition only works between **library overlays** (`.repoverlay/library/`). An overlay applied from GitHub or a local path cannot extend or include another overlay. See [The In-Repo Library](/guides/library/) for how to move overlays into the library.
+:::
 
 ## Overlay repository structure
 

--- a/website/src/content/docs/guides/how-it-works.md
+++ b/website/src/content/docs/guides/how-it-works.md
@@ -95,13 +95,15 @@ repoverlay cache remove owner/repo # Remove a specific cached repo
 repoverlay cache remove --all      # Remove all cached repos
 ```
 
+Configured sources (added with `repoverlay source add`) are cloned separately, to `~/.cache/repoverlay/sources/<name>/`. The `cache` subcommands operate only on the `github/` directory; source clones are refreshed automatically by commands that resolve from them (such as `browse` and `update`) and can be deleted manually — they are re-cloned on next use.
+
 ## Fork inheritance
 
 When you work on a **fork** of a repository, repoverlay can automatically inherit overlays from the **upstream** (parent) repository.
 
 ### Resolution order
 
-When you apply an overlay from a shared overlay repository, repoverlay checks:
+When you apply an overlay using a configured source reference (`org/repo/name`), repoverlay checks:
 
 1. **Direct match** — an overlay matching your fork's `org/repo`
 2. **Upstream fallback** — if no direct match exists and an `upstream` remote is configured, an overlay matching the upstream's `org/repo`

--- a/website/src/content/docs/guides/library.md
+++ b/website/src/content/docs/guides/library.md
@@ -1,0 +1,70 @@
+---
+title: The In-Repo Library
+sidebar:
+  order: 6
+---
+
+The library is a directory of overlays stored *inside* a repository, at `.repoverlay/library/` by default. Unlike applied overlay files, library overlays are tracked by git — commit them and everyone who clones the repo gets them.
+
+Use the library when:
+
+- A team wants to ship optional config (editor settings, AI configs) with the repo itself, instead of hosting a separate overlay repository
+- You want overlays that [extend or include](/guides/creating/#composing-overlays) other overlays — composition only works between library overlays
+
+## Applying library overlays
+
+Library overlays are resolved by bare name, before any configured source:
+
+```bash
+repoverlay apply my-overlay
+```
+
+If `.repoverlay/library/my-overlay/` exists, that's what gets applied.
+
+## Adding overlays to the library
+
+Create a new overlay directly in the library:
+
+```bash
+# Create into the library and apply it
+repoverlay create my-overlay --into library
+
+# Create into the library without applying
+repoverlay create my-overlay --into library --no-apply
+```
+
+Import an existing overlay — from a path, a GitHub URL, an `org/repo/name` reference, or the name of an already-applied overlay:
+
+```bash
+repoverlay library import ./path/to/overlay
+repoverlay library import org/repo/overlay-name --name shared-config
+```
+
+Or move an applied overlay's source into the library:
+
+```bash
+repoverlay move my-overlay --to library
+```
+
+If the library path is covered by `.gitignore`, repoverlay appends a negation pattern (for example `!.repoverlay/library/`) so the library stays tracked.
+
+## Listing, exporting, and removing
+
+```bash
+# List overlays in the library
+repoverlay library list
+
+# Copy a library overlay out to a directory
+repoverlay library export my-overlay --to ../shared-overlays/my-overlay
+
+# Delete a library overlay (--force if it's currently applied)
+repoverlay library remove my-overlay
+```
+
+## Custom library location
+
+Set `library_path` in the per-repo config (`.repoverlay/config.ccl`) to move the library. The path must be relative to the repo root:
+
+```
+library_path = tools/overlays
+```

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -29,7 +29,7 @@ Get up and running with repoverlay in under two minutes.
    repoverlay status
    ```
 
-   You should see: `No overlays applied.`
+   You should see: `Status: No overlays are currently applied.`
 
 3. **Browse and apply an overlay**
 


### PR DESCRIPTION
## Summary

Documents the in-repo library and overlay composition, and brings the rest of the docs in line with the current code.

### Website
- **New guide: The In-Repo Library** (`guides/library.md`, added to the sidebar) — covers applying library overlays by bare name, `create --into library`, `library import/export/list/remove`, `move --to library`, and the gitignore negation behavior.
- **Creating guide**: new "Composing overlays" section documenting `extends`, `includes`, and precedence rules (composition is library-only); documents the optional `overlay.description` field and multi-destination `mappings` (repeated source keys).
- **Applying guide**: renames "overlay repository references" to **configured source references** to match current resolution behavior; documents the `REPOVERLAY_DEFAULT_REPO_NAME` and `REPOVERLAY_MERGE` environment variables.
- **How it works**: explains that configured sources are cloned to `~/.cache/repoverlay/sources/<name>/` separately from the GitHub cache, and updates fork-inheritance wording.
- **Quick start**: corrects the `status` output string to match the CLI.

### Repo docs
- **ARCHITECTURE.md**: updates the module layout to the current `src/` (split-out `resolve`/`reference`/`status`/`remove`/`create` modules, git helpers, support modules, and the profile subsystem), documents the profile-apply data flow, and rewrites the state file format section for the internally tagged `OverlaySource` enum (replacing the old pipe-delimited encoding).
- **README.md**: marks profiles, plugins, and marketplaces as **experimental** with a warning (commands are hidden pending announcement), expands the profile config example with `instructions`/`plugins` keys, and documents the `overlay` and `extends`/`includes` config sections.
- **DEV.md**: updates the changie kinds/components list and adds a note on vendored agent skills.

### Config
- `.changie.yaml`: removes the unused `create-local` and `list` components.
- `.mcp.json`: adds context7 and semble MCP servers for contributor tooling.