### PR TITLE
refactor: introduce ApplyOptions struct to replace 10-parameter apply signatures

### DIFF
--- a/src/cli/commands/browse.rs
+++ b/src/cli/commands/browse.rs
@@ -13,8 +13,8 @@ use crate::sources::list_overlays_in_dir;
 use crate::state::{OverlaySource, ResolvedVia};
 use crate::upstream::detect_repo_identity;
 use crate::{
-    CacheManager, ConflictStrategy, ResolvedSource, apply_multiple_overlays, canonicalize_path,
-    config, get_cached_repo_commit, library, list_applied_overlays, list_overlays_from_cached_repo,
+    CacheManager, ResolvedSource, apply_multiple_overlays, canonicalize_path, config,
+    get_cached_repo_commit, library, list_applied_overlays, list_overlays_from_cached_repo,
     selection::is_interactive, validate_git_repo,
 };
 
@@ -549,10 +549,10 @@ where
     apply_multiple_overlays(
         &sources,
         &target,
-        false,
-        dry_run,
-        ConflictStrategy::default(),
-        false,
+        &crate::ApplyOptions {
+            dry_run,
+            ..crate::ApplyOptions::default()
+        },
     )?;
 
     Ok(())

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -190,14 +190,11 @@ pub(crate) fn create_into_library(
             crate::apply_overlay(
                 &overlay_source,
                 &target,
-                false,
-                Some(overlay_name),
-                None,
-                false,
-                crate::ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &crate::ApplyOptions {
+                    name_override: Some(overlay_name),
+                    conflict_strategy: crate::ConflictStrategy::Force,
+                    ..crate::ApplyOptions::default()
+                },
             )?;
         }
     }
@@ -256,14 +253,10 @@ pub(crate) fn create_overlay_command(
             crate::apply_overlay(
                 &overlay_source,
                 source,
-                false,
-                None,
-                None,
-                false,
-                crate::ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &crate::ApplyOptions {
+                    conflict_strategy: crate::ConflictStrategy::Force,
+                    ..crate::ApplyOptions::default()
+                },
             )?;
         }
 
@@ -340,14 +333,11 @@ pub(crate) fn create_overlay_command(
         crate::apply_overlay(
             &overlay_source,
             source,
-            false,
-            Some(overlay_name),
-            None,
-            false,
-            crate::ConflictStrategy::Force,
-            false,
-            None,
-            false,
+            &crate::ApplyOptions {
+                name_override: Some(overlay_name),
+                conflict_strategy: crate::ConflictStrategy::Force,
+                ..crate::ApplyOptions::default()
+            },
         )?;
 
         return Ok(());
@@ -380,14 +370,11 @@ pub(crate) fn create_overlay_command(
     crate::apply_overlay(
         &overlay_source,
         source,
-        false,
-        Some(overlay_name),
-        None,
-        false,
-        crate::ConflictStrategy::Force,
-        false,
-        None,
-        false,
+        &crate::ApplyOptions {
+            name_override: Some(overlay_name),
+            conflict_strategy: crate::ConflictStrategy::Force,
+            ..crate::ApplyOptions::default()
+        },
     )?;
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 
 use crate::reference::SourceReference;
 use crate::{
-    ConflictStrategy, apply_overlay, config, repair_git_exclude, restore_overlays, show_status,
-    show_status_json, status_has_overlays, switch_overlay,
+    ApplyOptions, ConflictStrategy, apply_overlay, config, repair_git_exclude, restore_overlays,
+    show_status, show_status_json, status_has_overlays, switch_overlay,
     update::{check_for_updates, version_string},
     update_overlays,
 };
@@ -795,14 +795,16 @@ pub(crate) fn run() -> Result<()> {
             apply_overlay(
                 &source,
                 &target,
-                copy,
-                name,
-                r#ref.as_deref(),
-                !no_update,
-                conflict_strategy,
-                merge,
-                from_source.as_deref(),
-                dry_run,
+                &ApplyOptions {
+                    force_copy: copy,
+                    name_override: name,
+                    ref_override: r#ref,
+                    update_cache: !no_update,
+                    conflict_strategy,
+                    merge,
+                    source_filter: from_source,
+                    dry_run,
+                },
             )?;
         }
         Commands::Remove {
@@ -946,13 +948,16 @@ pub(crate) fn run() -> Result<()> {
             switch_overlay(
                 &source,
                 &target,
-                copy,
-                name,
-                r#ref.as_deref(),
-                !no_update, // default: sync before switching
-                conflict_strategy,
-                merge,
-                dry_run,
+                &ApplyOptions {
+                    force_copy: copy,
+                    name_override: name,
+                    ref_override: r#ref,
+                    update_cache: !no_update, // default: sync before switching
+                    conflict_strategy,
+                    merge,
+                    dry_run,
+                    ..ApplyOptions::default()
+                },
             )?;
         }
         Commands::Cache { command } => {
@@ -1180,14 +1185,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -1216,14 +1214,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok());
 
@@ -1239,14 +1230,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true, // copy mode
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok());
 
@@ -1266,14 +1253,7 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -1306,14 +1286,7 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -1340,14 +1313,7 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -1366,14 +1332,10 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("custom-name".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("custom-name".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -1389,14 +1351,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 dir.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_err());
             assert!(
@@ -1416,28 +1371,20 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("already applied"));
@@ -1453,14 +1400,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("Conflict"));
@@ -1475,28 +1415,20 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("first".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("first".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("second".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("second".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_err());
             let err = result.unwrap_err().to_string();
@@ -1514,14 +1446,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "force should allow overwriting: {result:?}");
 
@@ -1539,14 +1467,10 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -1554,14 +1478,11 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "force should allow re-applying: {result:?}");
         }
@@ -1580,14 +1501,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "skip_conflicts should succeed: {result:?}");
 
@@ -1615,14 +1532,10 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -1630,14 +1543,11 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_err(), "skip_conflicts should fail on same-name");
             assert!(result.unwrap_err().to_string().contains("already applied"));
@@ -1662,14 +1572,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -1702,14 +1608,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "skip_conflicts should succeed: {result:?}");
 
@@ -1745,14 +1647,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
 
             assert!(result.is_ok(), "skip_conflicts should succeed: {result:?}");
@@ -1775,14 +1673,10 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("first".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("first".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -1791,14 +1685,11 @@ mod tests {
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("second".to_string()),
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("second".to_string()),
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_err(),
@@ -1820,14 +1711,10 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("first".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("first".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -1837,14 +1724,11 @@ mod tests {
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("second".to_string()),
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("second".to_string()),
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "skip_conflicts should succeed: {result:?}");
 
@@ -1872,14 +1756,7 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -1896,14 +1773,10 @@ mod tests {
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_err(),
@@ -1933,14 +1806,7 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -1958,14 +1824,10 @@ mod tests {
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "skip_conflicts should succeed: {result:?}");
 
@@ -1984,14 +1846,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("No files found"));
@@ -2000,18 +1855,7 @@ mod tests {
         #[test]
         fn fails_on_nonexistent_source() {
             let repo = create_test_repo();
-            let result = apply_overlay(
-                "/nonexistent/path",
-                repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
-            );
+            let result = apply_overlay("/nonexistent/path", repo.path(), &ApplyOptions::default());
             assert!(result.is_err());
         }
 
@@ -2035,14 +1879,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -2082,14 +1919,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true, // copy mode
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -2126,14 +1959,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -2164,14 +1990,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             // Should succeed (just warns about missing directory)
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
@@ -2203,14 +2022,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
 
             assert!(result.is_err());
@@ -2234,14 +2046,7 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -2258,14 +2063,7 @@ mod tests {
             let result = apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
 
             assert!(result.is_err());
@@ -2288,14 +2086,7 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -2324,14 +2115,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok());
 
@@ -2362,14 +2146,7 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -2412,14 +2189,7 @@ directories =
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_ok(), "apply_overlay failed: {result:?}");
 
@@ -2443,14 +2213,11 @@ directories =
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                true, // dry_run
+                &ApplyOptions {
+                    name_override: Some("test-overlay".to_string()),
+                    dry_run: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "apply_overlay dry_run failed: {result:?}");
 
@@ -2482,14 +2249,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             remove_overlay(repo.path(), Some("test-overlay".to_string()), false, false).unwrap();
@@ -2508,27 +2271,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2551,27 +2306,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2590,14 +2337,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             assert!(repo.path().join(".vscode").exists());
@@ -2621,14 +2364,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             remove_overlay(repo.path(), Some("test".to_string()), false, false).unwrap();
@@ -2648,14 +2387,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             remove_overlay(repo.path(), Some("test".to_string()), false, false).unwrap();
@@ -2685,14 +2420,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("real-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("real-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2710,14 +2441,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2748,14 +2475,7 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .unwrap();
 
@@ -2789,14 +2509,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true, // copy mode
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2821,14 +2537,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2856,27 +2568,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2917,14 +2621,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2948,14 +2648,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -2988,14 +2684,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3012,27 +2704,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3049,27 +2733,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3085,14 +2761,10 @@ directories =
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("real".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("real".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3645,14 +3317,10 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("first-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("first-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3663,13 +3331,10 @@ directories =
             let result = switch_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("second-overlay".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::default(),
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("second-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "switch_overlay failed: {result:?}");
 
@@ -3694,13 +3359,10 @@ directories =
             let result = switch_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("new-overlay".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::default(),
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("new-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok());
 
@@ -3715,13 +3377,7 @@ directories =
             let result = switch_overlay(
                 overlay.path().to_str().unwrap(),
                 target.path(),
-                false,
-                None,
-                None,
-                false, // no update for local paths
-                ConflictStrategy::default(),
-                false,
-                false,
+                &ApplyOptions::default(),
             );
             assert!(result.is_err());
             assert!(
@@ -3743,27 +3399,19 @@ directories =
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3775,13 +3423,10 @@ directories =
             switch_overlay(
                 overlay3.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("overlay-c".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::default(),
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-c".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -3804,13 +3449,11 @@ directories =
             let result = switch_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::Force,
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3838,13 +3481,11 @@ directories =
             let result = switch_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::SkipConflicts,
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3878,13 +3519,10 @@ directories =
             let result = switch_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("my-overlay".to_string()),
-                None,
-                false, // no update for local paths
-                ConflictStrategy::default(),
-                false,
-                false,
+                &ApplyOptions {
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_err(),

--- a/src/create.rs
+++ b/src/create.rs
@@ -4,6 +4,7 @@ use log::debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::ApplyOptions;
 use crate::ConflictStrategy;
 use crate::OverlayName;
 use crate::apply_overlay;
@@ -139,7 +140,7 @@ pub(crate) fn restore_overlays(
         };
 
         let ref_override = match &state.source {
-            OverlaySource::GitHub { git_ref, .. } => Some(git_ref.as_str()),
+            OverlaySource::GitHub { git_ref, .. } => Some(git_ref.clone()),
             OverlaySource::Local { .. }
             | OverlaySource::Library { .. }
             | OverlaySource::OverlayRepo { .. } => None,
@@ -150,14 +151,14 @@ pub(crate) fn restore_overlays(
         match apply_overlay(
             &source_str,
             &target,
-            false, // Use symlinks by default
-            Some(state.name.clone()),
-            ref_override,
-            true, // Update cache
-            ConflictStrategy::Force,
-            merge,
-            None,  // Use default source resolution for restore
-            false, // Not a dry run
+            &ApplyOptions {
+                name_override: Some(state.name.clone()),
+                ref_override,
+                update_cache: true,
+                conflict_strategy: ConflictStrategy::Force,
+                merge,
+                ..ApplyOptions::default()
+            },
         ) {
             Ok(()) => {
                 println!("  {} Restored '{}'", "✓".green(), state.name);
@@ -392,14 +393,14 @@ pub(crate) fn update_overlays(
             apply_overlay(
                 url,
                 &target,
-                false,
-                Some(state.name.clone()),
-                Some(git_ref.as_str()),
-                true,
-                conflict_strategy,
-                merge,
-                None,  // Use default source resolution for update
-                false, // Not a dry run
+                &ApplyOptions {
+                    name_override: Some(state.name.clone()),
+                    ref_override: Some(git_ref.clone()),
+                    update_cache: true,
+                    conflict_strategy,
+                    merge,
+                    ..ApplyOptions::default()
+                },
             )?;
         }
     }
@@ -835,18 +836,7 @@ pub(crate) fn create_overlay_with_files(
 ///
 /// 1. Remove all existing overlays (if any)
 /// 2. Apply the new overlay
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-pub(crate) fn switch_overlay(
-    source: &str,
-    target: &Path,
-    copy: bool,
-    name: Option<String>,
-    ref_override: Option<&str>,
-    update_cache: bool,
-    conflict_strategy: ConflictStrategy,
-    merge: bool,
-    dry_run: bool,
-) -> Result<()> {
+pub(crate) fn switch_overlay(source: &str, target: &Path, options: &ApplyOptions) -> Result<()> {
     validate_git_repo(target)?;
 
     // Check if any overlays are currently applied
@@ -856,23 +846,12 @@ pub(crate) fn switch_overlay(
     if has_overlays {
         println!("{} existing overlays...", "Removing".yellow().bold());
         // Remove all existing overlays
-        remove_overlay(target, None, true, dry_run)?;
+        remove_overlay(target, None, true, options.dry_run)?;
     }
 
     // Apply the new overlay
     println!("{} new overlay...", "Applying".blue().bold());
-    apply_overlay(
-        source,
-        target,
-        copy,
-        name,
-        ref_override,
-        update_cache,
-        conflict_strategy,
-        merge,
-        None,
-        dry_run,
-    )?;
+    apply_overlay(source, target, options)?;
 
     Ok(())
 }
@@ -1088,14 +1067,7 @@ mod tests {
             apply_overlay(
                 ctx.overlay_source(),
                 ctx.repo_path(),
-                false, // use symlinks
-                None,  // auto-name
-                None,  // no ref override
-                false, // don't update cache
-                ConflictStrategy::default(),
-                false,
-                None,  // default source resolution
-                false, // not dry run
+                &ApplyOptions::default(),
             )
             .expect("apply should succeed");
 
@@ -1188,14 +1160,7 @@ mod tests {
             apply_overlay(
                 ctx.overlay_source(),
                 ctx.repo_path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .expect("apply should succeed");
 
@@ -1251,27 +1216,19 @@ mod tests {
             apply_overlay(
                 overlay_a.path().to_str().unwrap(),
                 ctx.repo_path(),
-                false,
-                Some("overlay-a".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-a".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .expect("first apply should succeed");
             apply_overlay(
                 overlay_b.path().to_str().unwrap(),
                 ctx.repo_path(),
-                false,
-                Some("overlay-b".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("overlay-b".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .expect("second apply should succeed");
 
@@ -1301,27 +1258,19 @@ mod tests {
             apply_overlay(
                 overlay_a.path().to_str().unwrap(),
                 ctx.repo_path(),
-                false,
-                Some("restorable".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("restorable".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .expect("first apply should succeed");
             apply_overlay(
                 overlay_b.path().to_str().unwrap(),
                 ctx.repo_path(),
-                false,
-                Some("missing-source".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("missing-source".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .expect("second apply should succeed");
 
@@ -1365,14 +1314,7 @@ mod tests {
             apply_overlay(
                 ctx.overlay_source(),
                 ctx.repo_path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .expect("apply should succeed");
 
@@ -1399,14 +1341,7 @@ mod tests {
             apply_overlay(
                 ctx.overlay_source(),
                 ctx.repo_path(),
-                false,
-                None,
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions::default(),
             )
             .expect("re-apply should succeed");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,35 @@ pub(crate) enum ConflictStrategy {
     Interactive,
 }
 
+/// Options controlling how an overlay is applied.
+///
+/// `ApplyOptions::default()` matches `repoverlay apply <source>` with no
+/// flags: symlink (not copy), no name/ref override, no cache refresh, fail on
+/// conflict, no JSON merging, default source resolution, and a real (non-dry)
+/// run.
+// The bools mirror independent CLI switches (--copy, --no-update, --merge,
+// --dry-run); collapsing them into enums would only obscure that mapping.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ApplyOptions {
+    /// Copy files instead of symlinking them.
+    pub(crate) force_copy: bool,
+    /// Overlay name override (priority: CLI override > config > directory name).
+    pub(crate) name_override: Option<String>,
+    /// Git ref override for GitHub sources.
+    pub(crate) ref_override: Option<String>,
+    /// Refresh cached GitHub sources before resolving.
+    pub(crate) update_cache: bool,
+    /// How conflicts with existing files and overlays are handled.
+    pub(crate) conflict_strategy: ConflictStrategy,
+    /// Merge JSON files on conflict instead of failing.
+    pub(crate) merge: bool,
+    /// Restrict resolution to the named configured source.
+    pub(crate) source_filter: Option<String>,
+    /// Report what would happen without making changes.
+    pub(crate) dry_run: bool,
+}
+
 /// Result of an interactive conflict prompt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InteractiveChoice {
@@ -299,55 +328,36 @@ fn show_file_diff(existing_path: &Path, overlay_path: &Path, display_path: &Path
 /// - Overlay with same name already exists (unless using `Force` strategy)
 /// - File conflicts with existing overlay or repo file (unless using `Force` or `SkipConflicts`)
 /// - No files found in overlay source
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-pub(crate) fn apply_overlay(
-    source_str: &str,
-    target: &Path,
-    force_copy: bool,
-    name_override: Option<String>,
-    ref_override: Option<&str>,
-    update_cache: bool,
-    conflict_strategy: ConflictStrategy,
-    merge: bool,
-    source_filter: Option<&str>,
-    dry_run: bool,
-) -> Result<()> {
+pub(crate) fn apply_overlay(source_str: &str, target: &Path, options: &ApplyOptions) -> Result<()> {
     debug!(
         "apply_overlay: source={}, target={}, force_copy={}, name_override={:?}, conflict_strategy={:?}, dry_run={}",
         source_str,
         target.display(),
-        force_copy,
-        name_override,
-        conflict_strategy,
-        dry_run
+        options.force_copy,
+        options.name_override,
+        options.conflict_strategy,
+        options.dry_run
     );
 
     // Resolve source (handles GitHub URLs and local paths)
     // Pass target to enable upstream detection for fork inheritance
     let resolved = resolve_source(
         source_str,
-        ref_override,
-        update_cache,
+        options.ref_override.as_deref(),
+        options.update_cache,
         Some(target),
-        source_filter,
+        options.source_filter.as_deref(),
     )?;
 
     // Handle multi-select from browse mode
     let resolved = match resolved {
         ResolvedSources::Single(single) => single,
         ResolvedSources::Multiple(sources) => {
-            return apply_multiple_overlays(
-                &sources,
-                target,
-                force_copy,
-                dry_run,
-                conflict_strategy,
-                merge,
-            );
+            return apply_multiple_overlays(&sources, target, options);
         }
     };
 
-    if dry_run {
+    if options.dry_run {
         println!("{} Dry run - no changes made.", "Note:".yellow());
         println!("\nWould apply overlay from: {}", resolved.path.display());
         return Ok(());
@@ -357,14 +367,7 @@ pub(crate) fn apply_overlay(
     let target = canonicalize_path(target, "Target directory")?;
     validate_git_repo(&target)?;
 
-    apply_resolved_overlay(
-        &resolved,
-        &target,
-        force_copy,
-        name_override,
-        conflict_strategy,
-        merge,
-    )
+    apply_resolved_overlay(&resolved, &target, options)
 }
 
 /// RAII guard that removes overlay files created during a single
@@ -426,11 +429,15 @@ impl Drop for OverlayApplyGuard {
 pub(crate) fn apply_resolved_overlay(
     resolved: &ResolvedSource,
     target: &Path,
-    force_copy: bool,
-    name_override: Option<String>,
-    conflict_strategy: ConflictStrategy,
-    merge: bool,
+    options: &ApplyOptions,
 ) -> Result<()> {
+    let ApplyOptions {
+        force_copy,
+        conflict_strategy,
+        merge,
+        ..
+    } = *options;
+    let name_override = options.name_override.clone();
     let source = &resolved.path;
     debug!("resolved source path: {}", source.display());
 
@@ -1072,11 +1079,9 @@ fn rollback_created_overlay_entries(target: &Path, state: &OverlayState) {
 pub(crate) fn apply_multiple_overlays(
     sources: &[ResolvedSource],
     target: &Path,
-    force_copy: bool,
-    dry_run: bool,
-    conflict_strategy: ConflictStrategy,
-    merge: bool,
+    options: &ApplyOptions,
 ) -> Result<()> {
+    let conflict_strategy = options.conflict_strategy;
     let target = canonicalize_path(target, "Target directory")?;
     validate_git_repo(&target)?;
 
@@ -1130,7 +1135,7 @@ pub(crate) fn apply_multiple_overlays(
         }
     }
 
-    if dry_run {
+    if options.dry_run {
         println!("\n{} Dry run - no changes made.", "Note:".yellow());
         println!("\nWould apply {} overlay(s):", sources.len());
         for resolved in sources {
@@ -1142,15 +1147,14 @@ pub(crate) fn apply_multiple_overlays(
     // Phase 3: Apply each overlay, tracking for rollback
     let mut applied: Vec<String> = Vec::new();
 
+    // A single name override cannot apply to several overlays.
+    let per_overlay_options = ApplyOptions {
+        name_override: None,
+        ..options.clone()
+    };
+
     for resolved in sources {
-        match apply_resolved_overlay(
-            resolved,
-            &target,
-            force_copy,
-            None,
-            conflict_strategy,
-            merge,
-        ) {
+        match apply_resolved_overlay(resolved, &target, &per_overlay_options) {
             Ok(()) => {
                 let config = load_overlay_config(&resolved.path)?;
                 let name = determine_overlay_name(&config, &resolved.path, None)?;
@@ -2330,14 +2334,10 @@ mod tests {
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                false,
-                Some("unsafe".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    name_override: Some("unsafe".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
 
             assert!(result.is_err());
@@ -2694,14 +2694,7 @@ mod tests {
             ];
 
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_multiple_overlays(
-                &sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_multiple_overlays(&sources, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "multi-apply should succeed: {result:?}");
 
             // Both overlays should be applied
@@ -2738,14 +2731,7 @@ mod tests {
             ];
 
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_multiple_overlays(
-                &sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_multiple_overlays(&sources, &canonical, &ApplyOptions::default());
             assert!(result.is_err(), "should fail due to conflict");
 
             // No overlays should be applied
@@ -2778,10 +2764,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &sources,
                 &canonical,
-                false,
-                true,
-                ConflictStrategy::default(),
-                false,
+                &ApplyOptions {
+                    dry_run: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "dry run should succeed");
 
@@ -2817,14 +2803,7 @@ mod tests {
             ];
 
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_multiple_overlays(
-                &sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_multiple_overlays(&sources, &canonical, &ApplyOptions::default());
             assert!(
                 result.is_err(),
                 "should fail because config.json already exists"
@@ -2874,14 +2853,8 @@ mod tests {
                 path: overlay_a.path().to_path_buf(),
                 source_info: OverlaySource::local(overlay_a.path().to_path_buf()),
             }];
-            let result = apply_multiple_overlays(
-                &first_sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result =
+                apply_multiple_overlays(&first_sources, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "first apply should succeed: {result:?}");
 
             // Now try to apply both, including the already-applied overlay_a
@@ -2895,14 +2868,8 @@ mod tests {
                     source_info: OverlaySource::local(overlay_b.path().to_path_buf()),
                 },
             ];
-            let result = apply_multiple_overlays(
-                &second_sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result =
+                apply_multiple_overlays(&second_sources, &canonical, &ApplyOptions::default());
             assert!(
                 result.is_err(),
                 "should fail because overlay is already applied"
@@ -2938,10 +2905,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &sources,
                 &canonical,
-                false,
-                true,
-                ConflictStrategy::default(),
-                false,
+                &ApplyOptions {
+                    dry_run: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -2993,14 +2960,7 @@ mod tests {
             ];
 
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_multiple_overlays(
-                &sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_multiple_overlays(&sources, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "three overlays should succeed: {result:?}");
 
             let applied = list_applied_overlays(&canonical).unwrap();
@@ -3035,10 +2995,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &sources,
                 &canonical,
-                true,
-                false,
-                ConflictStrategy::default(),
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3091,14 +3051,8 @@ mod tests {
                 path: overlay_a.path().to_path_buf(),
                 source_info: OverlaySource::local(overlay_a.path().to_path_buf()),
             }];
-            let result = apply_multiple_overlays(
-                &first_sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result =
+                apply_multiple_overlays(&first_sources, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "first apply should succeed: {result:?}");
 
             // Now re-apply overlay_a along with overlay_b using Force
@@ -3115,10 +3069,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &second_sources,
                 &canonical,
-                false,
-                false,
-                ConflictStrategy::Force,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3148,10 +3102,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &sources,
                 &canonical,
-                false,
-                false,
-                ConflictStrategy::Force,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3187,10 +3141,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &sources,
                 &canonical,
-                false,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3229,24 +3183,18 @@ mod tests {
                 path: overlay_a.path().to_path_buf(),
                 source_info: OverlaySource::local(overlay_a.path().to_path_buf()),
             }];
-            let result = apply_multiple_overlays(
-                &first_sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result =
+                apply_multiple_overlays(&first_sources, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "first apply should succeed: {result:?}");
 
             // Try re-applying with SkipConflicts — should still fail for same-name
             let result = apply_multiple_overlays(
                 &first_sources,
                 &canonical,
-                false,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_err(),
@@ -3278,15 +3226,7 @@ mod tests {
                 path: overlay_a.path().to_path_buf(),
                 source_info: OverlaySource::local(overlay_a.path().to_path_buf()),
             }];
-            apply_multiple_overlays(
-                &first_sources,
-                &canonical,
-                false,
-                false,
-                ConflictStrategy::default(),
-                false,
-            )
-            .unwrap();
+            apply_multiple_overlays(&first_sources, &canonical, &ApplyOptions::default()).unwrap();
 
             // Apply overlay_b with SkipConflicts — should skip .envrc but apply unique.txt
             let second_sources = vec![ResolvedSource {
@@ -3296,10 +3236,10 @@ mod tests {
             let result = apply_multiple_overlays(
                 &second_sources,
                 &canonical,
-                false,
-                false,
-                ConflictStrategy::SkipConflicts,
-                false,
+                &ApplyOptions {
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(
                 result.is_ok(),
@@ -3337,10 +3277,10 @@ mod tests {
             apply_resolved_overlay(
                 &resolved,
                 &canonical,
-                true,
-                None,
-                ConflictStrategy::default(),
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             )
         }
 
@@ -3504,10 +3444,10 @@ mod tests {
             let result = apply_resolved_overlay(
                 &resolved,
                 &canonical,
-                true,
-                None,
-                ConflictStrategy::default(),
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_ok(), "apply should succeed: {result:?}");
 
@@ -3548,14 +3488,7 @@ mod tests {
                 source_info: OverlaySource::local(overlay),
             };
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_resolved_overlay(
-                &resolved,
-                &canonical,
-                false, // symlink mode: the whole directory would be linked as-is
-                None,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_resolved_overlay(&resolved, &canonical, &ApplyOptions::default());
             let err = result.expect_err("apply should reject directory with escaping symlink");
             assert!(
                 err.to_string().contains("escape") || format!("{err:#}").contains("escape"),
@@ -3588,14 +3521,7 @@ mod tests {
                 source_info: OverlaySource::local(overlay.path().to_path_buf()),
             };
             let canonical = repo.path().canonicalize().unwrap();
-            let result = apply_resolved_overlay(
-                &resolved,
-                &canonical,
-                false,
-                None,
-                ConflictStrategy::default(),
-                false,
-            );
+            let result = apply_resolved_overlay(&resolved, &canonical, &ApplyOptions::default());
             assert!(result.is_ok(), "apply should succeed: {result:?}");
             assert!(
                 canonical.join(".claude/CLAUDE.md").exists(),
@@ -4198,10 +4124,12 @@ mod tests {
             let result = apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("symlink-target".to_string()),
-                ConflictStrategy::Fail,
-                true,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("symlink-target".to_string()),
+                    merge: true,
+                    ..ApplyOptions::default()
+                },
             );
 
             assert!(result.is_err());
@@ -4235,10 +4163,12 @@ mod tests {
             let result = apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("symlink-ancestor".to_string()),
-                ConflictStrategy::Fail,
-                true,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("symlink-ancestor".to_string()),
+                    merge: true,
+                    ..ApplyOptions::default()
+                },
             );
 
             assert!(result.is_err());
@@ -4276,10 +4206,13 @@ mod tests {
             let result = apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("write-failure".to_string()),
-                ConflictStrategy::SkipConflicts,
-                true,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("write-failure".to_string()),
+                    conflict_strategy: ConflictStrategy::SkipConflicts,
+                    merge: true,
+                    ..ApplyOptions::default()
+                },
             );
 
             fs::set_permissions(&locked_dir, original_permissions).unwrap();
@@ -4309,10 +4242,11 @@ mod tests {
             let result = apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("exclude-fails".to_string()),
-                ConflictStrategy::Fail,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("exclude-fails".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
 
             assert!(result.is_err());
@@ -4347,10 +4281,11 @@ mod tests {
             apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("my-overlay".to_string()),
-                ConflictStrategy::Fail,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("my-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             assert_eq!(
@@ -4370,10 +4305,12 @@ mod tests {
             apply_resolved_overlay(
                 &resolved2,
                 repo.path(),
-                true,
-                Some("my-overlay".to_string()),
-                ConflictStrategy::Interactive,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("my-overlay".to_string()),
+                    conflict_strategy: ConflictStrategy::Interactive,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -4404,10 +4341,11 @@ mod tests {
             apply_resolved_overlay(
                 &resolved,
                 repo.path(),
-                true,
-                Some("batch-test".to_string()),
-                ConflictStrategy::Fail,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("batch-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -4430,10 +4368,11 @@ mod tests {
             apply_multiple_overlays(
                 &[resolved2],
                 repo.path(),
-                true,
-                false,
-                ConflictStrategy::Interactive,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    conflict_strategy: ConflictStrategy::Interactive,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5102,28 +5041,22 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("dup-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("dup-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
             let result = apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("dup-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("dup-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             );
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("already applied"));
@@ -5138,14 +5071,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("force-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("force-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5156,14 +5086,12 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("force-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::Force,
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("force-test".to_string()),
+                    conflict_strategy: ConflictStrategy::Force,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5181,14 +5109,12 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("dry-run-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                true, // dry_run
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("dry-run-test".to_string()),
+                    dry_run: true,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5215,14 +5141,10 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                None, // no name override
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5248,14 +5170,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("override-name".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("override-name".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5281,14 +5200,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("mapped".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("mapped".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -5316,14 +5232,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("dir-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("dir-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 

--- a/src/profile_plan.rs
+++ b/src/profile_plan.rs
@@ -252,14 +252,10 @@ fn execute_profile_action(
             crate::apply_overlay(
                 &reference,
                 target,
-                false,
-                None,
-                None,
-                true,
-                crate::ConflictStrategy::Fail,
-                false,
-                None,
-                false,
+                &crate::ApplyOptions {
+                    update_cache: true,
+                    ..crate::ApplyOptions::default()
+                },
             )?;
             let after = crate::state::list_applied_overlays(target)?;
             let new_overlays: Vec<_> = after

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -306,7 +306,7 @@ mod tests {
     mod remove_single_overlay_tests {
         use super::*;
         use crate::state::{FileEntry, LinkType, OverlayState};
-        use crate::{ConflictStrategy, apply_overlay};
+        use crate::{ApplyOptions, apply_overlay};
 
         fn create_test_repo_with_overlay() -> (TempDir, String) {
             let repo = create_test_repo();
@@ -316,14 +316,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true, // copy mode so we don't need to keep overlay dir alive
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -421,14 +418,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true, // copy mode
-                Some("nested-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("nested-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -554,7 +548,7 @@ mod tests {
     // Tests for remove_overlay
     mod remove_overlay_tests {
         use super::*;
-        use crate::{ConflictStrategy, apply_overlay};
+        use crate::{ApplyOptions, apply_overlay};
 
         #[test]
         fn remove_all_removes_all_overlays() {
@@ -568,28 +562,22 @@ mod tests {
             apply_overlay(
                 overlay1.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("overlay-1".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("overlay-1".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
             apply_overlay(
                 overlay2.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("overlay-2".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("overlay-2".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -614,14 +602,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("test-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("test-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -650,14 +635,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -681,14 +663,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -712,14 +691,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("only-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("only-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -741,14 +717,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("exclude-cleanup-fails".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("exclude-cleanup-fails".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -789,27 +762,21 @@ mod tests {
             apply_overlay(
                 overlay_one.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("one".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("one".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
             apply_overlay(
                 overlay_two.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("two".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("two".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -818,13 +818,15 @@ fn resolve_three_part(
         );
         return resolve_from_sources_with_suggestions(
             &config.sources,
-            org,
-            repo,
-            name,
-            upstream.as_ref(),
-            source_filter,
-            update,
-            target_path,
+            &SourceLookup {
+                org,
+                repo,
+                name,
+                upstream: upstream.as_ref(),
+                source_filter,
+                update,
+                repo_root: target_path,
+            },
         );
     }
 
@@ -837,18 +839,36 @@ fn resolve_three_part(
     )
 }
 
+/// A three-part overlay lookup (`org/repo/name`) plus the context that shapes
+/// how configured sources are searched.
+struct SourceLookup<'a> {
+    org: &'a str,
+    repo: &'a str,
+    name: &'a str,
+    /// Upstream of a fork, for fallback resolution.
+    upstream: Option<&'a upstream::UpstreamInfo>,
+    /// Restrict resolution to the named configured source.
+    source_filter: Option<&'a str>,
+    /// Refresh sources before resolving.
+    update: bool,
+    /// Repository root, for repo-local source configuration.
+    repo_root: Option<&'a Path>,
+}
+
 /// Resolve an overlay from configured sources with fuzzy suggestions on failure.
-#[allow(clippy::too_many_arguments)]
 fn resolve_from_sources_with_suggestions(
     sources: &[config::Source],
-    org: &str,
-    repo: &str,
-    name: &str,
-    upstream: Option<&upstream::UpstreamInfo>,
-    source_filter: Option<&str>,
-    update: bool,
-    repo_root: Option<&Path>,
+    lookup: &SourceLookup<'_>,
 ) -> Result<ResolvedSource> {
+    let &SourceLookup {
+        org,
+        repo,
+        name,
+        upstream,
+        source_filter,
+        update,
+        repo_root,
+    } = lookup;
     let manager = sources::SourceManager::new(sources.to_vec(), repo_root)?;
 
     prepare_sources_for_resolution(&manager, sources, source_filter, update)?;

--- a/src/status.rs
+++ b/src/status.rs
@@ -432,7 +432,7 @@ mod tests {
     // Tests for show_status
     mod show_status_tests {
         use super::*;
-        use crate::{ConflictStrategy, apply_overlay};
+        use crate::{ApplyOptions, apply_overlay};
 
         #[test]
         fn status_no_overlays_succeeds() {
@@ -451,14 +451,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("status-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("status-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -475,14 +472,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("filtered-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("filtered-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -499,14 +493,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("real-overlay".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("real-overlay".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -521,7 +512,7 @@ mod tests {
 
     mod status_has_overlays_tests {
         use super::*;
-        use crate::{ConflictStrategy, apply_overlay};
+        use crate::{ApplyOptions, apply_overlay};
 
         #[test]
         fn no_overlays_returns_false() {
@@ -539,14 +530,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("check-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("check-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -561,7 +549,7 @@ mod tests {
 
     mod show_status_json_tests {
         use super::*;
-        use crate::{ConflictStrategy, apply_overlay};
+        use crate::{ApplyOptions, apply_overlay};
 
         #[test]
         fn json_no_overlays_outputs_empty_array() {
@@ -580,14 +568,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("json-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("json-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -604,14 +589,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("json-filter-test".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("json-filter-test".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 
@@ -628,14 +610,11 @@ mod tests {
             apply_overlay(
                 overlay.path().to_str().unwrap(),
                 repo.path(),
-                true,
-                Some("real-json".to_string()),
-                None,
-                false,
-                ConflictStrategy::default(),
-                false,
-                None,
-                false,
+                &ApplyOptions {
+                    force_copy: true,
+                    name_override: Some("real-json".to_string()),
+                    ..ApplyOptions::default()
+                },
             )
             .unwrap();
 


### PR DESCRIPTION
Fixes #369

`ApplyOptions` (deriving `Default`) replaces the 10-positional-parameter signature on `apply_overlay` and threads through `apply_resolved_overlay`, `apply_multiple_overlays`, `switch_overlay`, `restore_overlays`, and `update_overlays`. All `clippy::too_many_arguments` / `fn_params_excessive_bools` allows on these functions are removed; the struct carries one documented `struct_excessive_bools` allow since its bools mirror independent CLI switches.

Call sites now name only the non-default options (`&ApplyOptions { conflict_strategy: ConflictStrategy::Force, ..ApplyOptions::default() }`), which deletes the `false, // Use symlinks by default`-style positional comment noise — 142 call sites converted.

`resolve_from_sources_with_suggestions` (resolve.rs) gets the same treatment via a private `SourceLookup` struct, dropping its `too_many_arguments` allow.

`apply_multiple_overlays` clears `name_override` for its per-overlay applies (a single name can't apply to several overlays), preserving the previous explicit-`None` behavior.

Internal only; no changelog fragment.