### PR TITLE
fix: reserve the @global overlay namespace

### DIFF
--- a/.changes/unreleased/Changed-20260627-081000.yaml
+++ b/.changes/unreleased/Changed-20260627-081000.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    Reserve the `@global` overlay namespace
+
+    Overlay sources now skip the reserved `@global` and `@library` directories instead of treating them as `org/repo/name` overlays, and neither can be addressed as a literal org, repo, or overlay name. This lets clients tolerate sources that use the upcoming global-overlay feature.
+time: 2026-06-27T08:10:00-07:00

--- a/src/library.rs
+++ b/src/library.rs
@@ -18,6 +18,18 @@ const DEFAULT_LIBRARY_DIR: &str = "library";
 /// Reserved source name for the library.
 pub(crate) const LIBRARY_SOURCE_NAME: &str = "@library";
 
+/// Reserved namespace for global overlays (overlays that apply to any repository).
+///
+/// On disk, global overlays live at `<source>/@global/<name>/`, a sibling of the
+/// `org/` directories in a structured source.
+pub(crate) const GLOBAL_NAMESPACE: &str = "@global";
+
+/// Returns `true` if `name` is a reserved namespace segment that must not be used
+/// as a literal `org`, `repo`, or overlay-name directory in a source.
+pub(crate) fn is_reserved_namespace(name: &str) -> bool {
+    name == LIBRARY_SOURCE_NAME || name == GLOBAL_NAMESPACE
+}
+
 /// Resolve the library path for a given repository root, loading repo config automatically.
 pub(crate) fn get_library_path(repo_root: &Path) -> Result<PathBuf> {
     let repo_config = config::load_repo_config(repo_root)?;

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -20,12 +20,18 @@ const OVERLAY_REPO_DIR: &str = "overlay-repo";
 
 /// Validate that a path component (org, repo, or overlay name) does not contain
 /// path traversal characters that could escape the overlay repository directory.
+///
+/// Reserved namespaces (e.g. `@global`, `@library`) are rejected so they cannot
+/// be addressed as literal `org`/`repo`/`name` segments.
 fn validate_path_component(s: &str, label: &str) -> Result<()> {
     if s.is_empty() {
         bail!("Invalid {label}: must not be empty");
     }
     if s == "." || s == ".." || s.contains('/') || s.contains('\\') {
         bail!("Invalid {label}: '{s}' contains path traversal characters");
+    }
+    if crate::library::is_reserved_namespace(s) {
+        bail!("Invalid {label}: '{s}' is a reserved namespace");
     }
     Ok(())
 }
@@ -338,8 +344,12 @@ impl OverlayRepoManager {
             let org_entry = org_entry?;
             let org_path = org_entry.path();
 
-            // Skip non-directories and hidden files
-            if !org_path.is_dir() || org_entry.file_name().to_string_lossy().starts_with('.') {
+            // Skip non-directories, hidden files, and reserved namespaces (e.g.
+            // @global) so older clients tolerate sources that use them.
+            if !org_path.is_dir()
+                || org_entry.file_name().to_string_lossy().starts_with('.')
+                || crate::library::is_reserved_namespace(&org_entry.file_name().to_string_lossy())
+            {
                 continue;
             }
 
@@ -1105,6 +1115,51 @@ mod tests {
         assert_eq!(overlays[0].org, "org");
         assert_eq!(overlays[0].repo, "repo");
         assert_eq!(overlays[0].name, "overlay");
+    }
+
+    #[test]
+    fn test_list_overlays_skips_global_namespace() {
+        let temp = TempDir::new().unwrap();
+        let repo_path = temp.path().join("overlay-repo");
+        fs::create_dir_all(repo_path.join(".git")).unwrap();
+
+        // A normal overlay plus a reserved @global namespace entry.
+        fs::create_dir_all(repo_path.join("org/repo/overlay")).unwrap();
+        fs::create_dir_all(repo_path.join("@global/my-global")).unwrap();
+        fs::write(repo_path.join("@global/my-global/.envrc"), "export FOO=1").unwrap();
+
+        let config = OverlayRepoConfig {
+            url: "https://github.com/org/overlays".to_string(),
+            local_path: Some(repo_path),
+        };
+
+        // Phase 0 tolerance: @global is skipped at the org level, never mis-parsed.
+        let manager = OverlayRepoManager::new(config).unwrap();
+        let overlays = manager.list_overlays().unwrap();
+
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].org, "org");
+        assert!(overlays.iter().all(|o| o.org != "@global"));
+    }
+
+    #[test]
+    fn test_get_overlay_path_rejects_reserved_namespace() {
+        let temp = TempDir::new().unwrap();
+        let repo_path = temp.path().join("overlay-repo");
+        fs::create_dir_all(repo_path.join("@global/repo/name")).unwrap();
+
+        let config = OverlayRepoConfig {
+            url: "https://github.com/org/overlays".to_string(),
+            local_path: Some(repo_path),
+        };
+        let manager = OverlayRepoManager::new(config).unwrap();
+
+        assert!(manager.get_overlay_path("@global", "repo", "name").is_err());
+        assert!(
+            manager
+                .get_overlay_path("@library", "repo", "name")
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -443,12 +443,16 @@ fn get_flat_overlay_path_in_dir(base: &Path, name: &str) -> Option<PathBuf> {
 }
 
 /// Validate path component safety for org/repo/overlay segments.
+///
+/// Reserved namespaces (e.g. `@global`, `@library`) are rejected so they cannot
+/// be addressed as literal `org`/`repo`/`name` segments.
 fn is_valid_path_component(component: &str) -> bool {
     !component.is_empty()
         && component != "."
         && component != ".."
         && !component.contains('/')
         && !component.contains('\\')
+        && !crate::library::is_reserved_namespace(component)
 }
 
 /// The detected layout of a local overlay source directory.
@@ -509,7 +513,9 @@ pub(crate) fn detect_source_layout(base: &Path) -> Result<SourceLayout> {
 }
 
 fn is_visible_candidate_dir(entry: &fs::DirEntry) -> Result<bool> {
-    if entry.file_name().to_string_lossy().starts_with('.') {
+    let name = entry.file_name();
+    let name = name.to_string_lossy();
+    if name.starts_with('.') || crate::library::is_reserved_namespace(&name) {
         return Ok(false);
     }
 
@@ -559,6 +565,12 @@ fn list_overlays_in_flat_dir(base: &Path) -> Result<Vec<AvailableOverlay>> {
             if path.is_file() {
                 has_root_files = true;
             }
+            continue;
+        }
+
+        // Reserved namespaces (e.g. @global) are not flat overlays; skip them so
+        // older clients tolerate sources that use them instead of mis-listing.
+        if crate::library::is_reserved_namespace(&name) {
             continue;
         }
 
@@ -1912,6 +1924,53 @@ mod tests {
         let overlays = list_overlays_in_dir(base).unwrap();
         assert_eq!(overlays.len(), 1);
         assert_eq!(overlays[0].name, "visible");
+    }
+
+    #[test]
+    fn test_list_overlays_in_dir_skips_global_namespace() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+
+        // A normal repo-scoped overlay alongside a reserved @global overlay.
+        create_local_source_dir(base, &[("org", "repo", "visible")]);
+        let global_overlay = base.join("@global").join("my-global");
+        fs::create_dir_all(&global_overlay).unwrap();
+        fs::write(global_overlay.join(".envrc"), "export FOO=bar").unwrap();
+
+        // Phase 0 tolerance: the @global namespace is skipped entirely, so only
+        // the repo-scoped overlay is listed (never mis-parsed as org/repo/name).
+        let overlays = list_overlays_in_dir(base).unwrap();
+        assert_eq!(overlays.len(), 1);
+        assert_eq!(overlays[0].name, "visible");
+        assert!(overlays.iter().all(|o| o.org != "@global"));
+    }
+
+    #[test]
+    fn test_global_namespace_not_treated_as_structured_layout() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+
+        // A source containing ONLY a @global overlay must not be detected as a
+        // structured org/repo/name source via the reserved namespace.
+        let global_overlay = base.join("@global").join("my-global");
+        fs::create_dir_all(&global_overlay).unwrap();
+        fs::write(global_overlay.join(".envrc"), "export FOO=bar").unwrap();
+
+        assert_eq!(detect_source_layout(base).unwrap(), SourceLayout::Flat);
+        assert!(list_overlays_in_dir(base).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_overlay_path_rejects_reserved_namespace_org() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+        let global_overlay = base.join("@global").join("repo").join("name");
+        fs::create_dir_all(&global_overlay).unwrap();
+        fs::write(global_overlay.join(".envrc"), "export FOO=bar").unwrap();
+
+        // @global / @library cannot be addressed as a literal org segment.
+        assert!(get_overlay_path_in_dir(base, "@global", "repo", "name").is_none());
+        assert!(get_overlay_path_in_dir(base, "@library", "repo", "name").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Phase 0 of the global-overlays rollout (tolerance patch)

This is a **standalone tolerance release** that teaches existing clients to degrade cleanly once sources start using the upcoming `@global` namespace. It ships **before** the feature itself (#stacked PR) so that consumers can upgrade first.

### What changes
- Reserve `@global` (and the existing `@library`) namespaces: source scanners **skip** these directories instead of mis-parsing them as `org/repo/name` overlays.
- Neither namespace can be addressed as a literal org, repo, or overlay name (path validators reject them).
- Added `GLOBAL_NAMESPACE` constant and `is_reserved_namespace()` helper.

### Why
Older binaries only skip `.`-prefixed directories, **not** `@`-prefixed ones, so a source containing `@global/<name>/` would be mis-parsed as an org named `@global`. This patch makes scanners tolerate (skip) the reserved namespace so that mixed-version fleets behave predictably while the global-overlays feature rolls out.
