### PR TITLE
feat: announce profiles publicly in 0.16.0

### DIFF
--- a/.changes/unreleased/Added-20260604-105823.yaml
+++ b/.changes/unreleased/Added-20260604-105823.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |-
+    Apply multiple profiles in a single agent run
+
+    `repoverlay copilot` and `repoverlay claude` now accept `--profile` more
+    than once, letting you stack several profiles into one ephemeral agent
+    session. Each profile is applied and locked independently, and all of them
+    are torn down automatically when the agent exits. If a profile fails to
+    apply, any profiles already applied in that run are rolled back so the
+    repository is left clean.
+time: 2026-06-04T10:58:23-07:00

--- a/.changes/unreleased/Added-20260605-123512.yaml
+++ b/.changes/unreleased/Added-20260605-123512.yaml
@@ -1,0 +1,17 @@
+kind: Added
+body: |-
+    Introduce profiles for agent-centric configuration
+
+    Profiles are a new way to compose overlays together with AI harness
+    capabilities — instruction files and plugins — into a single named,
+    loadable unit. Where an overlay describes *files to place in a repo*, a
+    profile describes *intent*: everything an agent needs for a given workflow.
+    Apply a profile to an ephemeral GitHub Copilot or Claude Code session with
+    `repoverlay copilot --profile <name>` or `repoverlay claude --profile
+    <name>`, and the harness places each capability in the right location.
+    Or apply one persistently with `repoverlay profile apply <name> --harness
+    <claude|copilot>` and manage it with `profile list/show/status/remove`.
+
+    See the guide for details:
+    https://repoverlay.tylerbutler.com/guides/profiles/
+time: 2026-06-05T12:35:12-07:00

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -468,7 +468,6 @@ enum Commands {
     },
 
     /// Manage repository profiles
-    #[command(hide = true)]
     Profile {
         #[command(subcommand)]
         command: ProfileCommand,
@@ -481,7 +480,6 @@ enum Commands {
     },
 
     /// Run GitHub Copilot with one or more profiles applied for the process lifetime
-    #[command(hide = true)]
     Copilot {
         /// Profile name to apply while Copilot runs (repeat to apply several)
         #[arg(long = "profile", required = true)]
@@ -497,7 +495,6 @@ enum Commands {
     },
 
     /// Run Claude with one or more profiles applied for the process lifetime
-    #[command(hide = true)]
     Claude {
         /// Profile name to apply while Claude runs (repeat to apply several)
         #[arg(long = "profile", required = true)]


### PR DESCRIPTION
## Changes

This PR contains the **source-code change** to make the profiles feature (shipped hidden in v0.15.0) public for the 0.16.0 release. It was split out of #350, which holds the accompanying website and documentation.

### CLI
- Un-hide the `profile`, `claude`, and `copilot` commands (remove `#[command(hide = true)]`) so they appear in `--help`

### Changelog
- Add the unreleased changelog fragments announcing profiles and multi-profile (`--profile` repeated) support; the next release renders as v0.16.0