### PR TITLE
docs: correct global-overlay minimum version and tidy changelog fragments

### DIFF
--- a/.changes/unreleased/Added-20260605-123513.yaml
+++ b/.changes/unreleased/Added-20260605-123513.yaml
@@ -8,4 +8,4 @@ body: |-
     are torn down automatically when the agent exits. If a profile fails to
     apply, any profiles already applied in that run are rolled back so the
     repository is left clean.
-time: 2026-06-04T10:58:23-07:00
+time: 2026-06-05T12:35:13-07:00

--- a/.changes/unreleased/Changed-20260627-081000.yaml
+++ b/.changes/unreleased/Changed-20260627-081000.yaml
@@ -1,6 +1,0 @@
-kind: Changed
-body: |-
-    Reserve the `@global` overlay namespace
-
-    Overlay sources now skip the reserved `@global` and `@library` directories instead of treating them as `org/repo/name` overlays, and neither can be addressed as a literal org, repo, or overlay name. This lets clients tolerate sources that use the upcoming global-overlay feature.
-time: 2026-06-27T08:10:00-07:00

--- a/website/src/content/docs/guides/creating.md
+++ b/website/src/content/docs/guides/creating.md
@@ -204,7 +204,7 @@ When a global overlay and a repo-scoped overlay share a name, the repo-scoped ov
 Global overlays don't change how overlays work — *any* overlay is technically applicable to any repository. You can apply an overlay defined for repo A onto repo B; resolution only cares about file paths and conflicts, not which repo an overlay was created for. The `@global` namespace simply makes that intent explicit and lets an overlay resolve for every repository without needing an `org/repo` match.
 
 :::caution[Minimum version]
-Global overlays rely on the reserved `@global` namespace. Clients that predate it (repoverlay **0.15.0** and earlier) do not understand `@global` and will mis-parse or ignore global overlays. The first release with full support — both consuming sources that use global overlays and creating/applying them — is repoverlay **0.16.0**. Make sure everyone sharing a source is on 0.16.0 or newer.
+Global overlays rely on the reserved `@global` namespace. Clients that predate it (repoverlay **0.16.0** and earlier) either do not understand `@global` at all or only skip it safely without resolving global overlays. The first release with full support — both consuming sources that use global overlays and creating/applying them — is repoverlay **0.17.0**. Make sure everyone sharing a source is on 0.17.0 or newer.
 :::
 
 ## Sharing overlays


### PR DESCRIPTION
## Summary

Corrects a version-number error in the global-overlays docs and tidies the unreleased changelog fragments after reviewing them for user-facing appropriateness.

## Changes

- **`guides/creating.md`** — The "Minimum version" callout claimed full global-overlay support (consuming *and* creating/applying) landed in **0.16.0**. In reality 0.16.0 only *reserves and safely skips* the `@global` namespace; the create/apply feature is still unreleased and ships in **0.17.0**. Updated the version boundary accordingly.
- **Removed duplicate changelog fragment** — `Changed-20260627-081000.yaml` ("Reserve the `@global` overlay namespace") was reintroduced by the global-overlays branch, but that entry already shipped in v0.16.0's CHANGELOG. Leaving it would double-list it in 0.17.0.
- **Re-timed the multiple-profiles fragment** — bumped its timestamp one second past the profiles-introduction fragment so changie orders "Apply multiple profiles in a single agent run" *after* "Introduce profiles for agent-centric configuration."

## Resulting 0.17.0 changelog order

1. Introduce profiles for agent-centric configuration
2. Apply multiple profiles in a single agent run
3. Global overlays that apply to any repository
