### PR TITLE
refactor: remove dead code and drop dialoguer/dirs deps

### DIFF
--- a/.changes/unreleased/Changed-20260712-101559.yaml
+++ b/.changes/unreleased/Changed-20260712-101559.yaml
@@ -1,0 +1,12 @@
+kind: Changed
+body: |-
+    Remove dead code and drop the dialoguer and dirs dependencies
+
+    An over-engineering audit removed ~850 lines: stale `#[allow(dead_code)]`
+    annotations and the code they hid (unused `GitRef::Tag` variant, test-only
+    helpers, speculative accessors, delegate-only wrappers), converted the
+    single-impl `SourceResolver` trait to inherent methods, and replaced
+    dialoguer with a small stdin prompt helper and dirs with
+    `std::env::home_dir()`. No user-visible behavior changes beyond plainer
+    confirm/input prompt rendering.
+time: 2026-07-12T10:15:59-07:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,18 +523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,15 +533,6 @@ name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
@@ -1586,9 +1565,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "ctrlc",
- "dialoguer",
  "directories",
- "dirs",
  "env_logger",
  "fuzzy-matcher",
  "glob",
@@ -1742,12 +1719,6 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2365,12 +2336,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,9 @@ anyhow = "1.0.102"
 colored = "3.1.1"
 url = "2.5.8"
 directories = "6.0.0"
-dialoguer = "0.12.0"
 ratatui = { version = "0.30.1", default-features = false, features = ["crossterm"] }
 tui-tree-widget = "0.24"
 sickle = { version = "0.4.0", features = ["serde"] }
-dirs = "6.0.0"
 fuzzy-matcher = "0.3.7"
 libc = "0.2.186"
 tiny-update-check = "1.1.3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -56,9 +56,6 @@ pub(crate) struct CachedOverlay {
     pub(crate) path: PathBuf,
     /// The resolved commit SHA
     pub(crate) commit: String,
-    /// When the cache was created/updated
-    #[allow(dead_code)]
-    pub(crate) cached_at: DateTime<Utc>,
 }
 
 /// Information about a cached repository.
@@ -134,7 +131,6 @@ impl CacheManager {
         };
 
         let commit = self.get_current_commit(&repo_path)?;
-        let cached_at = Utc::now();
 
         // Save cache metadata
         self.save_meta(&repo_path, source, &commit)?;
@@ -142,7 +138,6 @@ impl CacheManager {
         Ok(CachedOverlay {
             path: overlay_path,
             commit,
-            cached_at,
         })
     }
 
@@ -171,7 +166,7 @@ impl CacheManager {
 
         // If specific branch/tag, clone that
         match &source.git_ref {
-            GitRef::Branch(branch) | GitRef::Tag(branch) => {
+            GitRef::Branch(branch) => {
                 cmd.args(["--branch", branch]);
             }
             GitRef::Default | GitRef::Commit(_) => {
@@ -232,7 +227,6 @@ impl CacheManager {
                 debug!("remote ref not found, falling back to local: {b}");
                 b.as_str()
             }
-            GitRef::Tag(t) => t.as_str(),
             GitRef::Commit(c) => c.as_str(),
         };
 
@@ -419,8 +413,8 @@ impl CacheManager {
         let ref_spec = match &source.git_ref {
             GitRef::Default => "origin/HEAD".to_string(),
             GitRef::Branch(b) => format!("origin/{b}"),
-            GitRef::Tag(_) | GitRef::Commit(_) => {
-                // Tags and commits don't have "updates"
+            GitRef::Commit(_) => {
+                // Commits don't have "updates"
                 return Ok(None);
             }
         };
@@ -750,62 +744,6 @@ mod tests {
         let result = manager.check_for_updates(&source).unwrap();
 
         // Should return None for non-existent repo
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_check_for_updates_tag_returns_none() {
-        let temp = TempDir::new().unwrap();
-        let manager = CacheManager {
-            cache_dir: temp.path().to_path_buf(),
-        };
-
-        // Create a fake cached repo
-        let repo_path = temp.path().join("github/owner/repo");
-        fs::create_dir_all(&repo_path).unwrap();
-
-        // Initialize as git repo
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(&repo_path)
-            .output()
-            .unwrap();
-
-        // Configure git user for commit
-        std::process::Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(&repo_path)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(&repo_path)
-            .output()
-            .unwrap();
-
-        // Create an initial commit
-        fs::write(repo_path.join("file.txt"), "content").unwrap();
-        std::process::Command::new("git")
-            .args(["add", "."])
-            .current_dir(&repo_path)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["commit", "-m", "initial"])
-            .current_dir(&repo_path)
-            .output()
-            .unwrap();
-
-        // Parse as tag source - tags don't have "updates"
-        let source = GitHubSource {
-            owner: "owner".to_string(),
-            repo: "repo".to_string(),
-            git_ref: GitRef::Tag("v1.0.0".to_string()),
-            subpath: None,
-        };
-
-        let result = manager.check_for_updates(&source).unwrap();
-        // Tags don't have updates, should return None
         assert!(result.is_none());
     }
 

--- a/src/cli/commands/edit.rs
+++ b/src/cli/commands/edit.rs
@@ -10,7 +10,7 @@ use crate::config::load_config;
 use crate::detection::{DetectedFile, FileCategory};
 use crate::overlay_repo::OverlayRepoManager;
 use crate::selection::{SelectionConfig, select_files};
-use crate::state::{EntryType, FileEntry, LinkType, OverlaySource, SourceResolver};
+use crate::state::{EntryType, FileEntry, LinkType, OverlaySource};
 use crate::{
     OverlayName, canonicalize_path, list_applied_overlays, load_all_overlay_targets,
     load_overlay_state, normalize_overlay_name, save_external_state, save_overlay_state,
@@ -30,27 +30,12 @@ enum RollbackEntry {
     },
 }
 
-/// Edit an existing applied overlay by re-selecting files interactively.
-pub(crate) fn edit_overlay(name_arg: &str, target: &std::path::Path, dry_run: bool) -> Result<()> {
-    interactive_edit_overlay(name_arg, target, dry_run)
-}
-
-/// Resolve an overlay's source to a local filesystem path.
-///
-/// Uses the `SourceResolver` trait to handle all source types uniformly:
-/// - Local: returns the stored path directly
-/// - `OverlayRepo`: reconstructs path from the overlay repo (respects `source_name`)
-/// - GitHub: returns the cached download path
-pub(crate) fn resolve_overlay_source_path(state: &crate::state::OverlayState) -> Result<PathBuf> {
-    state.source.resolve_local_path()
-}
-
 /// Interactively re-select which files from an overlay source should be applied.
 ///
 /// Shows the selection UI with all files from the overlay source directory,
 /// pre-selecting the currently applied files. Computes the diff between the
 /// old and new selections and applies adds/removes accordingly.
-fn interactive_edit_overlay(name_arg: &str, target: &std::path::Path, dry_run: bool) -> Result<()> {
+pub(crate) fn edit_overlay(name_arg: &str, target: &std::path::Path, dry_run: bool) -> Result<()> {
     let target = canonicalize_path(target, "Target directory")?;
     crate::validate_git_repo(&target)?;
 
@@ -87,7 +72,7 @@ fn interactive_edit_overlay(name_arg: &str, target: &std::path::Path, dry_run: b
     }
 
     // Resolve overlay source to a local directory
-    let source_path = resolve_overlay_source_path(&state)?;
+    let source_path = state.source.resolve_local_path()?;
 
     if !source_path.exists() {
         bail!(
@@ -550,7 +535,7 @@ pub(crate) fn add_files_to_overlay(
         return Ok(());
     }
 
-    // Resolve the overlay source to a local path using the SourceResolver trait (#149).
+    // Resolve the overlay source to a local path via OverlaySource::resolve_local_path (#149).
     // This correctly handles Local, OverlayRepo (with source_name), and GitHub sources.
     let overlay_repo_path = state
         .source

--- a/src/cli/commands/marketplace.rs
+++ b/src/cli/commands/marketplace.rs
@@ -53,10 +53,10 @@ fn add_marketplace(name: &str, url: &str, yes: bool) -> Result<()> {
 
     // Marketplaces introduce executable behavior; confirm before registering.
     if !yes && is_interactive() {
-        let confirmed = dialoguer::Confirm::new()
-            .with_prompt(format!("Register marketplace '{name}' from {expanded}?"))
-            .default(true)
-            .interact()?;
+        let confirmed = crate::prompt::confirm(
+            &format!("Register marketplace '{name}' from {expanded}?"),
+            true,
+        )?;
         if !confirmed {
             println!("Aborted.");
             return Ok(());

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -17,7 +17,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::selection::{FlatSelectionConfig, SelectableItem, ToSelectableItem, select_flat};
-use crate::state::{OverlaySource, SourceResolver};
+use crate::state::OverlaySource;
 use crate::{
     OVERLAYS_DIR, STATE_DIR, canonicalize_path, list_applied_overlays, remove_overlay,
     remove_single_overlay, selection::is_interactive, state, validate_git_repo,

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -6,7 +6,7 @@ use super::create::{auto_commit_overlay, parse_overlay_name_arg};
 use crate::config::load_config;
 use crate::overlay_repo::OverlayRepoManager;
 use crate::selection::{FlatSelectionConfig, SelectableItem, ToSelectableItem, select_flat};
-use crate::state::{OverlaySource, SourceResolver};
+use crate::state::OverlaySource;
 use crate::{
     canonicalize_path, list_applied_overlays, load_overlay_state, normalize_overlay_name,
     selection::is_interactive,
@@ -42,7 +42,7 @@ pub(crate) fn handle_sync(
             let mut state = load_overlay_state(&target, overlay_name.as_str())?;
             crate::try_upgrade_github_source(&target, &mut state)?;
 
-            // Use SourceResolver to check syncability (#146, #149)
+            // Check syncability via the source (#146, #149)
             if !state.source.is_syncable() {
                 let label = state.source.source_type_label();
                 println!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1100,7 +1100,6 @@ const fn conflict_strategy(
 mod tests {
     use super::*;
     use crate::cli::commands::create::{detect_target_repo, parse_overlay_name_arg};
-    use crate::cli::commands::edit::resolve_overlay_source_path;
     use crate::cli::commands::sync::sync_single_overlay;
     use crate::{create_overlay, remove_overlay};
     use std::fs;
@@ -5698,7 +5697,7 @@ directories =
     /// Regression tests for source-type dispatch bugs.
     ///
     /// These tests reproduce the bugs described in issues #142, #143, #145–#148.
-    /// They should fail on the `main` branch (before the `SourceResolver` fix)
+    /// They should fail on the `main` branch (before the source-resolution fix)
     /// and pass once the fix from #149 is applied.
     mod source_resolver_bugs {
         use super::*;
@@ -5745,7 +5744,7 @@ directories =
 
             // BUG: On main, this returns Err("Interactive edit is not supported for GitHub overlays")
             // EXPECTED: Should return Ok with a path (the cached path), not bail
-            let result = resolve_overlay_source_path(&state);
+            let result = state.source.resolve_local_path();
             assert!(
                 !result
                     .as_ref()
@@ -5759,7 +5758,7 @@ directories =
         // ==================== #143: add_files_to_overlay assumes overlay repo ====================
 
         /// Issue #143: `add_files_to_overlay` should use `resolve_local_path()` from
-        /// the `SourceResolver` trait for Local sources instead of going through the
+        /// source resolution for Local sources instead of going through the
         /// overlay repo code path. With the fix, `dry_run` succeeds for local sources
         /// by resolving directly to the local path.
         #[test]
@@ -5781,7 +5780,7 @@ directories =
             fs::write(repo.path().join(".envrc"), "export FOO=bar").unwrap();
             fs::write(repo.path().join("new-file.txt"), "new content").unwrap();
 
-            // With the SourceResolver fix (#149), add_files_to_overlay uses
+            // With the source-resolution fix (#149), add_files_to_overlay uses
             // resolve_local_path() which returns the local path directly for
             // Local sources — no overlay repo lookup needed.
             let result = add_files_to_overlay(
@@ -5846,12 +5845,10 @@ directories =
         // ==================== #145: update shows wrong message for OverlayRepo ====================
 
         /// Issue #145: `update_overlays` should distinguish `OverlayRepo` from Local
-        /// sources. With the `SourceResolver` fix (#149), `source_type_label()` returns
+        /// sources. With the source-resolution fix (#149), `source_type_label()` returns
         /// different labels and `is_updatable()` returns different values for each.
         #[test]
         fn issue_145_update_code_should_handle_overlay_repo_separately() {
-            use crate::state::SourceResolver;
-
             let local_source = OverlaySource::local(PathBuf::from("/path"));
             let repo_source = OverlaySource::overlay_repo(
                 "org".to_string(),
@@ -5860,7 +5857,7 @@ directories =
                 "abc".to_string(),
             );
 
-            // SourceResolver provides distinct labels for each source type
+            // Source resolution provides distinct labels for each source type
             assert_ne!(
                 local_source.source_type_label(),
                 repo_source.source_type_label(),
@@ -6078,7 +6075,7 @@ directories =
             // get_default_overlay_repo_config() (ignoring source_name) and fail
             // with "Overlay repository not configured" rather than a source-name-aware
             // error like "Source 'secondary-source' not found in configuration".
-            let result = resolve_overlay_source_path(&state);
+            let result = state.source.resolve_local_path();
             assert!(
                 result.is_err(),
                 "Expected error (no config available in test env)"

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,12 +121,6 @@ impl Source {
         self.path.is_some()
     }
 
-    /// Returns `true` if this is a git-based source.
-    #[allow(dead_code)] // Utility method for callers
-    pub(crate) const fn is_git(&self) -> bool {
-        self.url.is_some()
-    }
-
     /// Get the URL. Returns an error if this is a local source.
     pub(crate) fn url(&self) -> Result<&str> {
         self.url.as_deref().ok_or_else(|| {
@@ -145,22 +139,6 @@ impl Source {
                 self.name
             )
         })
-    }
-
-    /// Validate that exactly one of url or path is set.
-    #[allow(dead_code)] // Utility method; used in tests
-    pub(crate) fn validate(&self) -> Result<()> {
-        match (&self.url, &self.path) {
-            (Some(_), None) | (None, Some(_)) => Ok(()),
-            (Some(_), Some(_)) => anyhow::bail!(
-                "Source '{}' has both url and path; only one is allowed",
-                self.name
-            ),
-            (None, None) => anyhow::bail!(
-                "Source '{}' has neither url nor path; one is required",
-                self.name
-            ),
-        }
     }
 }
 
@@ -431,7 +409,7 @@ fn config_dir_with_env(xdg: Option<&str>) -> Result<PathBuf> {
     let base = if let Some(xdg) = xdg {
         PathBuf::from(xdg)
     } else {
-        dirs::home_dir()
+        std::env::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
             .join(".config")
     };
@@ -982,7 +960,6 @@ sources =
         let source = &config.sources[0];
         assert!(source.url.is_none());
         assert!(source.path.is_none());
-        assert!(source.validate().is_err());
     }
 
     #[test]
@@ -1542,54 +1519,6 @@ sources =
         assert!(repo_config_path(temp.path()).exists());
     }
 
-    // ==================== Source validation tests ====================
-
-    #[test]
-    fn test_source_validate_url_only_ok() {
-        let source = Source {
-            name: "test".to_string(),
-            url: Some("https://github.com/org/repo".to_string()),
-            path: None,
-        };
-        assert!(source.validate().is_ok());
-        assert!(source.is_git());
-        assert!(!source.is_local());
-    }
-
-    #[test]
-    fn test_source_validate_path_only_ok() {
-        let source = Source {
-            name: "test".to_string(),
-            url: None,
-            path: Some(PathBuf::from("./my-overlays")),
-        };
-        assert!(source.validate().is_ok());
-        assert!(source.is_local());
-        assert!(!source.is_git());
-    }
-
-    #[test]
-    fn test_source_validate_both_set_err() {
-        let source = Source {
-            name: "test".to_string(),
-            url: Some("https://github.com/org/repo".to_string()),
-            path: Some(PathBuf::from("./my-overlays")),
-        };
-        let err = source.validate().unwrap_err();
-        assert!(err.to_string().contains("both url and path"));
-    }
-
-    #[test]
-    fn test_source_validate_neither_set_err() {
-        let source = Source {
-            name: "test".to_string(),
-            url: None,
-            path: None,
-        };
-        let err = source.validate().unwrap_err();
-        assert!(err.to_string().contains("neither url nor path"));
-    }
-
     // ==================== CCL serialization roundtrip for path sources ====================
 
     #[test]
@@ -1651,7 +1580,6 @@ sources =
             Some(Path::new("overlays"))
         );
         assert_eq!(parsed.sources[1].name, "remote");
-        assert!(parsed.sources[1].is_git());
         assert_eq!(
             parsed.sources[1].url().unwrap(),
             "https://github.com/org/overlays"

--- a/src/create.rs
+++ b/src/create.rs
@@ -209,17 +209,13 @@ pub(crate) fn create_overlay(
 
             // Get output directory from user if not specified
             let final_output = if output.is_none() {
-                use dialoguer::Input;
-
                 println!(
                     "Where should the overlay be created?\n\
                      (This directory will contain the overlay files and config)"
                 );
 
-                let path_str: String = Input::new()
-                    .with_prompt("Overlay directory")
-                    .default(output_dir.display().to_string())
-                    .interact_text()?;
+                let path_str =
+                    crate::prompt::input("Overlay directory", &output_dir.display().to_string())?;
 
                 PathBuf::from(path_str)
             } else {

--- a/src/github.rs
+++ b/src/github.rs
@@ -23,9 +23,6 @@ pub(crate) enum GitRef {
     Default,
     /// A branch name
     Branch(String),
-    /// A tag name (currently parsed as Branch, kept for future use)
-    #[allow(dead_code)]
-    Tag(String),
     /// A commit SHA (40 hex characters)
     Commit(String),
 }
@@ -102,33 +99,9 @@ impl GitHubSource {
         lower.starts_with("https://github.com/") || lower.starts_with("http://github.com/")
     }
 
-    /// Generate a unique cache directory name.
-    #[allow(dead_code)]
-    pub(crate) fn cache_key(&self) -> String {
-        let ref_part = match &self.git_ref {
-            GitRef::Default => "default".to_string(),
-            GitRef::Branch(b) => format!("branch-{}", sanitize_for_path(b)),
-            GitRef::Tag(t) => format!("tag-{}", sanitize_for_path(t)),
-            GitRef::Commit(c) => format!("commit-{}", &c[..12.min(c.len())]),
-        };
-        format!("{}__{}__{}", self.owner, self.repo, ref_part)
-    }
-
     /// Full clone URL for the repository.
     pub(crate) fn clone_url(&self) -> String {
         format!("https://github.com/{}/{}.git", self.owner, self.repo)
-    }
-
-    /// Human-readable display of the source.
-    #[allow(dead_code)]
-    pub(crate) fn display_url(&self) -> String {
-        let base = format!("https://github.com/{}/{}", self.owner, self.repo);
-        match (&self.git_ref, &self.subpath) {
-            (GitRef::Default, None) => base,
-            (GitRef::Default, Some(path)) => format!("{}/tree/HEAD/{}", base, path.display()),
-            (ref_, None) => format!("{}/tree/{}", base, ref_.as_str()),
-            (ref_, Some(path)) => format!("{}/tree/{}/{}", base, ref_.as_str(), path.display()),
-        }
     }
 
     /// Apply a ref override from CLI.
@@ -171,14 +144,8 @@ impl GitRef {
     pub(crate) fn as_str(&self) -> &str {
         match self {
             Self::Default => "HEAD",
-            Self::Branch(s) | Self::Tag(s) | Self::Commit(s) => s,
+            Self::Branch(s) | Self::Commit(s) => s,
         }
-    }
-
-    /// Check if this is the default ref.
-    #[allow(dead_code)]
-    pub(crate) const fn is_default(&self) -> bool {
-        matches!(self, Self::Default)
     }
 }
 
@@ -187,7 +154,6 @@ impl std::fmt::Display for GitRef {
         match self {
             Self::Default => write!(f, "(default branch)"),
             Self::Branch(s) => write!(f, "branch:{s}"),
-            Self::Tag(s) => write!(f, "tag:{s}"),
             Self::Commit(s) => write!(f, "commit:{}", &s[..12.min(s.len())]),
         }
     }
@@ -224,20 +190,6 @@ pub(crate) fn parse_remote_url(url: &str) -> Option<(String, String)> {
     }
 
     None
-}
-
-/// Sanitize a string for use in a filesystem path.
-#[allow(dead_code)]
-fn sanitize_for_path(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -343,21 +295,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_key() {
-        let source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        assert_eq!(source.cache_key(), "owner__repo__default");
-
-        let source = GitHubSource::parse("https://github.com/owner/repo/tree/main").unwrap();
-        assert_eq!(source.cache_key(), "owner__repo__branch-main");
-
-        let source = GitHubSource::parse(
-            "https://github.com/owner/repo/tree/abc123def456789012345678901234567890abcd",
-        )
-        .unwrap();
-        assert_eq!(source.cache_key(), "owner__repo__commit-abc123def456");
-    }
-
-    #[test]
     fn test_with_ref_override() {
         let source = GitHubSource::parse("https://github.com/owner/repo")
             .unwrap()
@@ -367,53 +304,11 @@ mod tests {
     }
 
     #[test]
-    fn test_display_url() {
-        let source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        assert_eq!(source.display_url(), "https://github.com/owner/repo");
-
-        let source = GitHubSource::parse("https://github.com/owner/repo/tree/main").unwrap();
-        assert_eq!(
-            source.display_url(),
-            "https://github.com/owner/repo/tree/main"
-        );
-
-        let source = GitHubSource::parse("https://github.com/owner/repo/tree/main/subdir").unwrap();
-        assert_eq!(
-            source.display_url(),
-            "https://github.com/owner/repo/tree/main/subdir"
-        );
-    }
-
-    #[test]
-    fn test_display_url_default_with_subpath() {
-        // Create source with default ref but with subpath
-        let mut source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        source.subpath = Some(PathBuf::from("some/path"));
-
-        assert_eq!(
-            source.display_url(),
-            "https://github.com/owner/repo/tree/HEAD/some/path"
-        );
-    }
-
-    #[test]
-    fn test_git_ref_is_default() {
-        assert!(GitRef::Default.is_default());
-        assert!(!GitRef::Branch("main".to_string()).is_default());
-        assert!(!GitRef::Tag("v1.0".to_string()).is_default());
-        assert!(!GitRef::Commit("abc123".to_string()).is_default());
-    }
-
-    #[test]
     fn test_git_ref_display() {
         assert_eq!(format!("{}", GitRef::Default), "(default branch)");
         assert_eq!(
             format!("{}", GitRef::Branch("main".to_string())),
             "branch:main"
-        );
-        assert_eq!(
-            format!("{}", GitRef::Tag("v1.0.0".to_string())),
-            "tag:v1.0.0"
         );
         assert_eq!(
             format!(
@@ -431,24 +326,6 @@ mod tests {
             format!("{}", GitRef::Commit("abc123".to_string())),
             "commit:abc123"
         );
-    }
-
-    #[test]
-    fn test_cache_key_tag() {
-        // Create a source and manually set it to a tag
-        let mut source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        source.git_ref = GitRef::Tag("v1.0.0".to_string());
-
-        assert_eq!(source.cache_key(), "owner__repo__tag-v1.0.0");
-    }
-
-    #[test]
-    fn test_sanitize_for_path() {
-        assert_eq!(sanitize_for_path("main"), "main");
-        assert_eq!(sanitize_for_path("feature/branch"), "feature_branch");
-        assert_eq!(sanitize_for_path("v1.0.0"), "v1.0.0");
-        assert_eq!(sanitize_for_path("branch-name_123"), "branch-name_123");
-        assert_eq!(sanitize_for_path("special!@#chars"), "special___chars");
     }
 
     #[test]
@@ -556,7 +433,6 @@ mod tests {
     fn test_git_ref_as_str() {
         assert_eq!(GitRef::Default.as_str(), "HEAD");
         assert_eq!(GitRef::Branch("main".to_string()).as_str(), "main");
-        assert_eq!(GitRef::Tag("v1.0".to_string()).as_str(), "v1.0");
         assert_eq!(GitRef::Commit("abc123".to_string()).as_str(), "abc123");
     }
 
@@ -710,7 +586,6 @@ mod tests {
             GitRef::Default,
             GitRef::Branch("main".to_string()),
             GitRef::Branch("feature/long-branch-name".to_string()),
-            GitRef::Tag("v1.2.3".to_string()),
             GitRef::Commit("abc123def456789012345678901234567890abcd".to_string()),
             GitRef::Commit("abc123".to_string()),
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod plugin;
 mod profile;
 mod profile_applicators;
 mod profile_plan;
+mod prompt;
 mod reference;
 mod remove;
 mod resolve;

--- a/src/overlay_repo.rs
+++ b/src/overlay_repo.rs
@@ -790,71 +790,10 @@ fn lexically_contained(link_path: &Path, target: &Path, root: &Path) -> bool {
     resolved.starts_with(root)
 }
 
-/// Parse an overlay reference in the format "org/repo/name".
-#[allow(dead_code)] // Kept for backward compatibility; new code uses reference::SourceReference
-pub(crate) fn parse_overlay_reference(s: &str) -> Option<(String, String, String)> {
-    // Must have exactly 3 parts separated by /
-    let parts: Vec<_> = s.split('/').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-
-    // Must not look like a path or URL
-    if s.starts_with('.') || s.starts_with('/') || s.contains("://") {
-        return None;
-    }
-
-    // Each part must be non-empty
-    if parts.iter().any(|p| p.is_empty()) {
-        return None;
-    }
-
-    Some((
-        parts[0].to_string(),
-        parts[1].to_string(),
-        parts[2].to_string(),
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
-
-    #[test]
-    fn test_parse_overlay_reference_valid() {
-        let result = parse_overlay_reference("microsoft/FluidFramework/claude-config");
-        assert!(result.is_some());
-        let (org, repo, name) = result.unwrap();
-        assert_eq!(org, "microsoft");
-        assert_eq!(repo, "FluidFramework");
-        assert_eq!(name, "claude-config");
-    }
-
-    #[test]
-    fn test_parse_overlay_reference_invalid_path() {
-        assert!(parse_overlay_reference("./local/path").is_none());
-        assert!(parse_overlay_reference("/absolute/path/here").is_none());
-    }
-
-    #[test]
-    fn test_parse_overlay_reference_invalid_url() {
-        assert!(parse_overlay_reference("https://github.com/owner/repo").is_none());
-    }
-
-    #[test]
-    fn test_parse_overlay_reference_wrong_parts() {
-        assert!(parse_overlay_reference("org/repo").is_none());
-        assert!(parse_overlay_reference("org/repo/name/extra").is_none());
-        assert!(parse_overlay_reference("single").is_none());
-    }
-
-    #[test]
-    fn test_parse_overlay_reference_empty_parts() {
-        assert!(parse_overlay_reference("org//name").is_none());
-        assert!(parse_overlay_reference("/repo/name").is_none());
-        assert!(parse_overlay_reference("org/repo/").is_none());
-    }
 
     #[test]
     fn test_default_overlay_repo_path() {

--- a/src/path_safety.rs
+++ b/src/path_safety.rs
@@ -25,7 +25,6 @@ use std::path::{Component, Path};
 ///
 /// For example, `src/config.rs` is accepted, while `/etc/passwd`,
 /// `../../../etc/passwd`, and empty paths are rejected.
-#[allow(dead_code)] // Infrastructure for future call-site migrations (#323)
 pub(crate) fn validate_repo_relative_path(path: &Path) -> Result<()> {
     // Reject empty paths
     if path.as_os_str().is_empty() {
@@ -82,54 +81,6 @@ pub(crate) fn validate_repo_relative_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Validate a path component (e.g., overlay name, org name, repo name).
-///
-/// This is stricter than `validate_repo_relative_path` and ensures the
-/// component is safe to use as a single directory or file name.
-///
-/// Rejects:
-/// - Empty strings
-/// - Path separators (`/` or `\`)
-/// - Current or parent directory references (`.`, `..`)
-/// - Control characters
-/// - Leading/trailing whitespace
-///
-/// # Errors
-///
-/// Returns an error if the component fails validation.
-///
-/// For example, `my-overlay` and `user_config` are accepted, while
-/// `../etc`, `name/with/slash`, and empty strings are rejected.
-#[allow(dead_code)] // Infrastructure for future call-site migrations (#323)
-pub(crate) fn validate_path_component(component: &str) -> Result<()> {
-    // Reject empty components
-    if component.is_empty() {
-        bail!("Path component cannot be empty");
-    }
-
-    // Reject leading/trailing whitespace
-    if component != component.trim() {
-        bail!("Path component cannot have leading/trailing whitespace: '{component}'");
-    }
-
-    // Reject path separators
-    if component.contains('/') || component.contains('\\') {
-        bail!("Path component cannot contain path separators: '{component}'");
-    }
-
-    // Reject current/parent directory references
-    if component == "." || component == ".." {
-        bail!("Path component cannot be '.' or '..': '{component}'");
-    }
-
-    // Reject control characters
-    if component.chars().any(char::is_control) {
-        bail!("Path component contains control characters: '{component}'");
-    }
-
-    Ok(())
-}
-
 /// Check if a path or any of its ancestors is a symlink.
 ///
 /// This walks from the repo root up to the target path (or its nearest
@@ -154,7 +105,6 @@ pub(crate) fn validate_path_component(component: &str) -> Result<()> {
 /// - `repo_root` is not a directory
 /// - Any existing ancestor of `target` is a symlink
 /// - I/O errors occur during traversal
-#[allow(dead_code)] // Infrastructure for future call-site migrations (#323)
 pub(crate) fn check_no_symlink_ancestors(repo_root: &Path, target: &Path) -> Result<()> {
     validate_repo_relative_path(target)?;
 
@@ -290,62 +240,6 @@ mod tests {
         // Path with null byte
         let path_with_null = PathBuf::from("file\0name.txt");
         let result = validate_repo_relative_path(&path_with_null);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("control"));
-    }
-
-    #[test]
-    fn test_validate_path_component_valid() {
-        assert!(validate_path_component("my-overlay").is_ok());
-        assert!(validate_path_component("user_config").is_ok());
-        assert!(validate_path_component("name123").is_ok());
-        assert!(validate_path_component("simple").is_ok());
-    }
-
-    #[test]
-    fn test_validate_path_component_empty() {
-        let result = validate_path_component("");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("empty"));
-    }
-
-    #[test]
-    fn test_validate_path_component_path_separator() {
-        let result = validate_path_component("name/with/slash");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("separator"));
-
-        let result = validate_path_component("name\\with\\backslash");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_validate_path_component_dot_references() {
-        let result = validate_path_component(".");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("'.'"));
-
-        let result = validate_path_component("..");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("'..'"));
-    }
-
-    #[test]
-    fn test_validate_path_component_whitespace() {
-        let result = validate_path_component(" leading");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("whitespace"));
-
-        let result = validate_path_component("trailing ");
-        assert!(result.is_err());
-
-        let result = validate_path_component(" both ");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_validate_path_component_control_chars() {
-        let result = validate_path_component("file\nname");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("control"));
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,7 +26,7 @@ pub(crate) enum InstallMode {
 
 /// A reference to a plugin from a profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) enum PluginRef {
     /// A plugin provided by a named marketplace.
     Marketplace {
@@ -223,7 +223,7 @@ impl Serialize for PluginRef {
 
 /// Origin of a resolved plugin bundle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) enum PluginOrigin {
     /// Bundle came from a cached git clone (commit-pinned).
     CachedGit,
@@ -233,7 +233,7 @@ pub(crate) enum PluginOrigin {
 
 /// Why a plugin must be delegated to the harness rather than managed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) enum DelegateReason {
     /// The plugin source is not a cloneable/introspectable git repo (e.g. `npm:`).
     NonGitSource,
@@ -241,7 +241,7 @@ pub(crate) enum DelegateReason {
 
 /// A fully resolved plugin reference.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) enum ResolvedPlugin {
     /// repoverlay located (and, for git sources, cached) an introspectable bundle.
     Bundle {
@@ -267,7 +267,7 @@ pub(crate) enum ResolvedPlugin {
 
 /// Introspected contents of a plugin bundle directory.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) struct PluginBundle {
     /// Parsed `.claude-plugin/plugin.json`, if present.
     pub(crate) manifest: Option<serde_json::Value>,
@@ -289,7 +289,6 @@ impl PluginBundle {
     ///
     /// Missing `.claude-plugin/plugin.json`, `.mcp.json`, `skills/`, or `agents/`
     /// are not errors — they yield empty/absent fields. Malformed JSON is an error.
-    #[allow(dead_code)]
     pub(crate) fn read(dir: &std::path::Path) -> anyhow::Result<Self> {
         use anyhow::Context;
 
@@ -571,7 +570,6 @@ fn local_git_commit(dir: &std::path::Path) -> Option<String> {
 ///
 /// `base_dir` is the directory that local relative plugin paths are resolved
 /// against (the target repository root).
-#[allow(dead_code)]
 pub(crate) fn resolve_plugin(
     reference: &PluginRef,
     marketplaces: &[crate::config::Marketplace],

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 
 use crate::profile_applicators::AgentHarness;
 
-#[allow(dead_code)]
 const PROFILES_DIR: &str = "profiles";
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -126,7 +125,6 @@ fn merge_list<T: Clone>(base: &[T], override_list: &[T]) -> Vec<T> {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn profile_state_path(
     target: &Path,
     name: &str,
@@ -249,19 +247,17 @@ pub(crate) fn validate_profile_marker_component(component: &str) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
 pub(crate) fn save_profile_state(target: &Path, state: &ProfileState) -> Result<()> {
     let path = profile_state_path(target, &state.name, state.harness)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     let content = sickle::to_string(state).context("Failed to serialize profile state")?;
-    crate::state::atomic_write(&path, &content)
+    crate::fs_util::atomic_write(&path, &content)
         .with_context(|| format!("Failed to write profile state: {}", path.display()))?;
     Ok(())
 }
 
-#[allow(dead_code)]
 pub(crate) fn load_profile_state(
     target: &Path,
     name: &str,
@@ -280,7 +276,6 @@ pub(crate) fn load_profile_state(
 /// filenames, because profile names may legally contain `.`. A file that fails
 /// to parse is skipped (with the error returned alongside its path) so a single
 /// corrupt state file does not abort bulk operations such as `update`.
-#[allow(dead_code)]
 pub(crate) fn list_applied_profile_states(target: &Path) -> Result<Vec<ProfileState>> {
     let dir = target.join(crate::state::STATE_DIR).join(PROFILES_DIR);
     if !dir.try_exists().unwrap_or(false) {
@@ -310,7 +305,6 @@ pub(crate) fn list_applied_profile_states(target: &Path) -> Result<Vec<ProfileSt
     Ok(states)
 }
 
-#[allow(dead_code)]
 pub(crate) fn remove_profile_state(target: &Path, name: &str, harness: AgentHarness) -> Result<()> {
     let path = profile_state_path(target, name, harness)?;
     if path.exists() {
@@ -322,14 +316,13 @@ pub(crate) fn remove_profile_state(target: &Path, name: &str, harness: AgentHarn
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[allow(dead_code)]
 pub(crate) enum ProfileMode {
     Persistent,
     Ephemeral,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) struct ProfileState {
     pub(crate) name: String,
     pub(crate) harness: AgentHarness,
@@ -351,7 +344,7 @@ pub(crate) struct ProfileState {
 /// Provenance for a managed plugin that was resolved, cached, and decomposed
 /// into native harness placements during apply.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) struct ProfilePluginEntry {
     pub(crate) reference: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -359,7 +352,7 @@ pub(crate) struct ProfilePluginEntry {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) struct ProfileFileEntry {
     pub(crate) source: PathBuf,
     pub(crate) target: PathBuf,
@@ -377,7 +370,6 @@ pub(crate) struct ProfileFileEntry {
 /// are repo-local; this only distinguishes the project/local settings split.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[allow(dead_code)]
 pub(crate) enum DelegateScope {
     /// `.claude/settings.json` (team-shareable, committed)
     Project,
@@ -386,7 +378,7 @@ pub(crate) enum DelegateScope {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[allow(dead_code)]
+
 pub(crate) struct SkippedCapability {
     pub(crate) capability: String,
     pub(crate) reason: String,

--- a/src/profile_applicators/mod.rs
+++ b/src/profile_applicators/mod.rs
@@ -128,7 +128,7 @@ impl AgentHarness {
         if let Some(home) = override_home {
             return Ok(home.into());
         }
-        let home = dirs::home_dir().context("Could not determine home directory")?;
+        let home = std::env::home_dir().context("Could not determine home directory")?;
         Ok(home.join(self.home_suffix()))
     }
 
@@ -432,7 +432,7 @@ mod tests {
 
     #[test]
     fn claude_home_defaults_to_dot_claude() {
-        let expected = dirs::home_dir().unwrap().join(".claude");
+        let expected = std::env::home_dir().unwrap().join(".claude");
         assert_eq!(
             AgentHarness::Claude.home_from_override(None).unwrap(),
             expected
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn copilot_home_defaults_to_config_github_copilot() {
-        let expected = dirs::home_dir()
+        let expected = std::env::home_dir()
             .unwrap()
             .join(".config")
             .join("github-copilot");

--- a/src/profile_plan.rs
+++ b/src/profile_plan.rs
@@ -366,7 +366,7 @@ fn execute_profile_action(
                     )
                 })?;
             }
-            crate::state::atomic_write(&region_target, &updated)?;
+            crate::fs_util::atomic_write(&region_target, &updated)?;
             state.files.push(ProfileFileEntry {
                 source: region_target.clone(),
                 target: region_target,
@@ -1160,7 +1160,7 @@ fn restore_merge_json_backup(
         fs::remove_file(&file.target)
             .with_context(|| format!("Failed to remove {}", file.target.display()))?;
     } else {
-        crate::state::atomic_write(&file.target, &serde_json::to_string_pretty(&current)?)?;
+        crate::fs_util::atomic_write(&file.target, &serde_json::to_string_pretty(&current)?)?;
     }
     if let Err(err) = fs::remove_file(&file.source) {
         eprintln!(
@@ -1221,7 +1221,7 @@ fn restore_managed_region(
         fs::remove_file(&file.target)
             .with_context(|| format!("Failed to remove {}", file.target.display()))?;
     } else {
-        crate::state::atomic_write(&file.target, &stripped)?;
+        crate::fs_util::atomic_write(&file.target, &stripped)?;
     }
     Ok(())
 }
@@ -1876,7 +1876,7 @@ fn merge_json_value(target: &Path, value: &Value, owned_paths: &[String]) -> Res
         let new_value = value.pointer(pointer).cloned().unwrap_or(Value::Null);
         set_json_pointer(&mut merged, pointer, new_value);
     }
-    crate::state::atomic_write(target, &serde_json::to_string_pretty(&merged)?)?;
+    crate::fs_util::atomic_write(target, &serde_json::to_string_pretty(&merged)?)?;
     Ok(())
 }
 
@@ -2066,7 +2066,7 @@ fn save_external_profile_snapshot(
     let manifest = dir.join(PROFILE_SNAPSHOT_MANIFEST);
     let content =
         serde_json::to_string_pretty(&snapshot).context("Failed to serialize profile snapshot")?;
-    crate::state::atomic_write(&manifest, &content)
+    crate::fs_util::atomic_write(&manifest, &content)
 }
 
 /// Mark a profile's external snapshot as removed so `restore` skips it.
@@ -2085,7 +2085,7 @@ pub(crate) fn remove_external_profile_snapshot(
             snapshot.removed_at = Some(chrono::Utc::now());
             let updated = serde_json::to_string_pretty(&snapshot)
                 .context("Failed to serialize profile snapshot")?;
-            crate::state::atomic_write(&manifest, &updated)
+            crate::fs_util::atomic_write(&manifest, &updated)
         }
         Err(err) => {
             warn!(

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,36 @@
+//! Minimal interactive stdin prompts.
+
+use anyhow::Result;
+use std::io::{self, Write};
+
+/// Ask a yes/no question, reading the answer from stdin.
+///
+/// Empty input selects `default`; only `y`/`yes` (case-insensitive) answers yes.
+pub(crate) fn confirm(prompt: &str, default: bool) -> Result<bool> {
+    let hint = if default { "Y/n" } else { "y/N" };
+    print!("{prompt} [{hint}] ");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(match line.trim().to_ascii_lowercase().as_str() {
+        "" => default,
+        "y" | "yes" => true,
+        _ => false,
+    })
+}
+
+/// Ask for a line of text, reading the answer from stdin.
+///
+/// Empty input returns `default`.
+pub(crate) fn input(prompt: &str, default: &str) -> Result<String> {
+    print!("{prompt} [{default}]: ");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let trimmed = line.trim();
+    Ok(if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    })
+}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -73,14 +73,14 @@ impl SourceReference {
 
         // Handle tilde expansion for home directory
         if input == "~" {
-            if let Some(home) = dirs::home_dir() {
+            if let Some(home) = std::env::home_dir() {
                 return Self::LocalPath {
                     path: home,
                     needs_prefix_warning: false,
                 };
             }
         } else if let Some(rest) = input.strip_prefix("~/")
-            && let Some(home) = dirs::home_dir()
+            && let Some(home) = std::env::home_dir()
         {
             return Self::LocalPath {
                 path: home.join(rest),
@@ -142,19 +142,6 @@ impl SourceReference {
             path: PathBuf::from(input),
             needs_prefix_warning: false,
         }
-    }
-
-    /// Check if this reference requires the user to add a `./` prefix.
-    #[must_use]
-    #[allow(dead_code)] // Available for future use
-    pub(crate) const fn needs_local_path_warning(&self) -> bool {
-        matches!(
-            self,
-            Self::LocalPath {
-                needs_prefix_warning: true,
-                ..
-            }
-        )
     }
 }
 
@@ -265,7 +252,7 @@ mod tests {
         } = result
         {
             // Should expand to home dir (if available)
-            if let Some(home) = dirs::home_dir() {
+            if let Some(home) = std::env::home_dir() {
                 assert_eq!(path, home);
             }
             assert!(!needs_prefix_warning);
@@ -301,7 +288,7 @@ mod tests {
             needs_prefix_warning,
         } = result
         {
-            if let Some(home) = dirs::home_dir() {
+            if let Some(home) = std::env::home_dir() {
                 assert_eq!(path, home.join("overlays/test"));
             }
             assert!(!needs_prefix_warning);
@@ -344,37 +331,6 @@ mod tests {
         } else {
             panic!("Expected TwoPart with whitespace preserved");
         }
-    }
-
-    #[test]
-    fn needs_local_path_warning_returns_false_for_explicit_paths() {
-        let reference = SourceReference::LocalPath {
-            path: PathBuf::from("./test"),
-            needs_prefix_warning: false,
-        };
-        assert!(!reference.needs_local_path_warning());
-    }
-
-    #[test]
-    fn needs_local_path_warning_returns_true_for_ambiguous_paths() {
-        let reference = SourceReference::LocalPath {
-            path: PathBuf::from("test"),
-            needs_prefix_warning: true,
-        };
-        assert!(reference.needs_local_path_warning());
-    }
-
-    #[test]
-    fn needs_local_path_warning_returns_false_for_non_local_path() {
-        let reference = SourceReference::GitHubUrl("https://github.com/a/b".to_string());
-        assert!(!reference.needs_local_path_warning());
-
-        let reference = SourceReference::ThreePart {
-            owner: "a".to_string(),
-            repo: "b".to_string(),
-            overlay: "c".to_string(),
-        };
-        assert!(!reference.needs_local_path_warning());
     }
 
     #[test]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -19,8 +19,8 @@ use crate::selection::is_interactive;
 use crate::sources;
 use crate::state;
 use crate::state::{
-    OverlaySource, OverlayState, ResolvedVia, SourceResolver, list_applied_overlays,
-    normalize_overlay_name, save_overlay_state,
+    OverlaySource, OverlayState, ResolvedVia, list_applied_overlays, normalize_overlay_name,
+    save_overlay_state,
 };
 use crate::upstream;
 use crate::upstream::detect_upstream;
@@ -604,10 +604,7 @@ fn prompt_save_source(owner: &str, repo: &str, target_path: Option<&Path>) -> Re
     let source_name = repo.to_string();
 
     let prompt = format!("Save {owner}/{repo} as a source for future use?");
-    let confirmed = dialoguer::Confirm::new()
-        .with_prompt(&prompt)
-        .default(true)
-        .interact()?;
+    let confirmed = crate::prompt::confirm(&prompt, true)?;
 
     if !confirmed {
         return Ok(());

--- a/src/snapshots/repoverlay__github__tests__snapshot_git_ref_display.snap
+++ b/src/snapshots/repoverlay__github__tests__snapshot_git_ref_display.snap
@@ -5,6 +5,5 @@ expression: "output.join(\"\\n\")"
 (default branch)
 branch:main
 branch:feature/long-branch-name
-tag:v1.2.3
 commit:abc123def456
 commit:abc123

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -139,15 +139,6 @@ impl SourceManager {
             .collect()
     }
 
-    /// Get a source by name.
-    #[allow(dead_code)] // Utility method for future use
-    pub(crate) fn get_source(&self, name: &str) -> Option<&Source> {
-        self.sources
-            .iter()
-            .find(|s| s.source.name == name)
-            .map(|s| &s.source)
-    }
-
     /// Ensure all git sources are cloned.
     pub(crate) fn ensure_all_cloned(&self) -> Result<()> {
         for ms in &self.sources {
@@ -299,53 +290,6 @@ impl SourceManager {
         }
 
         Ok(None)
-    }
-
-    /// Find all sources that have a specific overlay.
-    ///
-    /// Returns a list of (source, `resolved_via`) pairs for each source
-    /// that has the overlay.
-    #[allow(dead_code)] // Utility method for future `resolve` command
-    pub(crate) fn find_all_matches(
-        &self,
-        org: &str,
-        repo: &str,
-        name: &str,
-        upstream: Option<&UpstreamInfo>,
-    ) -> Result<Vec<(Source, ResolvedVia)>> {
-        let mut matches = Vec::new();
-
-        for ms in &self.sources {
-            match &ms.backend {
-                ManagedSourceBackend::Git(manager) => {
-                    if manager.needs_clone() {
-                        continue;
-                    }
-                    if let Some((_, resolved_via)) =
-                        manager.find_overlay_path_with_fallback(org, repo, name, upstream)?
-                    {
-                        matches.push((ms.source.clone(), resolved_via));
-                    }
-                }
-                ManagedSourceBackend::Local { path: base_path } => {
-                    if get_overlay_path_in_dir(base_path, org, repo, name).is_some() {
-                        matches.push((ms.source.clone(), ResolvedVia::Direct));
-                    } else if let Some(upstream_info) = upstream
-                        && get_overlay_path_in_dir(
-                            base_path,
-                            &upstream_info.org,
-                            &upstream_info.repo,
-                            name,
-                        )
-                        .is_some()
-                    {
-                        matches.push((ms.source.clone(), ResolvedVia::Upstream));
-                    }
-                }
-            }
-        }
-
-        Ok(matches)
     }
 
     /// List overlay names for a specific org/repo across all sources.
@@ -1191,68 +1135,6 @@ mod tests {
     }
 
     #[test]
-    fn test_find_all_matches() {
-        let temp = TempDir::new().unwrap();
-        let cache_dir = temp.path();
-
-        // Both sources have the overlay
-        let source1_path = cache_dir.join("personal");
-        let source2_path = cache_dir.join("team");
-        fs::create_dir_all(&source1_path).unwrap();
-        fs::create_dir_all(&source2_path).unwrap();
-
-        create_mock_source(
-            &source1_path,
-            &[("microsoft", "FluidFramework", "claude-config")],
-        );
-        create_mock_source(
-            &source2_path,
-            &[("microsoft", "FluidFramework", "claude-config")],
-        );
-
-        let sources = vec![
-            Source {
-                name: "personal".to_string(),
-                url: Some("file://dummy".to_string()),
-                path: None,
-            },
-            Source {
-                name: "team".to_string(),
-                url: Some("file://dummy".to_string()),
-                path: None,
-            },
-        ];
-
-        let manager = SourceManager {
-            sources: sources
-                .into_iter()
-                .map(|source| {
-                    let local_path = cache_dir.join(&source.name);
-                    let config = OverlayRepoConfig {
-                        url: source.url().unwrap().to_string(),
-                        local_path: Some(local_path),
-                    };
-                    ManagedSource {
-                        source,
-                        backend: ManagedSourceBackend::Git(
-                            OverlayRepoManager::new(config).unwrap(),
-                        ),
-                    }
-                })
-                .collect(),
-        };
-
-        // Should find in both sources
-        let matches = manager
-            .find_all_matches("microsoft", "FluidFramework", "claude-config", None)
-            .unwrap();
-
-        assert_eq!(matches.len(), 2);
-        assert_eq!(matches[0].0.name, "personal");
-        assert_eq!(matches[1].0.name, "team");
-    }
-
-    #[test]
     fn git_source_resolution_propagates_invalid_overlay_name() {
         let temp = TempDir::new().unwrap();
         let repo_path = temp.path().join("source");
@@ -1450,84 +1332,6 @@ mod tests {
 
         let names = manager.source_names();
         assert_eq!(names, vec!["personal", "team"]);
-    }
-
-    #[test]
-    fn test_get_source_found() {
-        let temp = TempDir::new().unwrap();
-        let cache_dir = temp.path();
-
-        let sources = vec![
-            Source {
-                name: "personal".to_string(),
-                url: Some("https://github.com/user/overlays".to_string()),
-                path: None,
-            },
-            Source {
-                name: "team".to_string(),
-                url: Some("https://github.com/team/overlays".to_string()),
-                path: None,
-            },
-        ];
-
-        let manager = SourceManager {
-            sources: sources
-                .into_iter()
-                .map(|source| {
-                    let local_path = cache_dir.join(&source.name);
-                    let config = OverlayRepoConfig {
-                        url: source.url().unwrap().to_string(),
-                        local_path: Some(local_path),
-                    };
-                    ManagedSource {
-                        source,
-                        backend: ManagedSourceBackend::Git(
-                            OverlayRepoManager::new(config).unwrap(),
-                        ),
-                    }
-                })
-                .collect(),
-        };
-
-        let source = manager.get_source("personal");
-        assert!(source.is_some());
-        let source = source.unwrap();
-        assert_eq!(source.name, "personal");
-        assert_eq!(source.url().unwrap(), "https://github.com/user/overlays");
-    }
-
-    #[test]
-    fn test_get_source_not_found() {
-        let temp = TempDir::new().unwrap();
-        let cache_dir = temp.path();
-
-        let sources = vec![Source {
-            name: "personal".to_string(),
-            url: Some("file://dummy".to_string()),
-            path: None,
-        }];
-
-        let manager = SourceManager {
-            sources: sources
-                .into_iter()
-                .map(|source| {
-                    let local_path = cache_dir.join(&source.name);
-                    let config = OverlayRepoConfig {
-                        url: source.url().unwrap().to_string(),
-                        local_path: Some(local_path),
-                    };
-                    ManagedSource {
-                        source,
-                        backend: ManagedSourceBackend::Git(
-                            OverlayRepoManager::new(config).unwrap(),
-                        ),
-                    }
-                })
-                .collect(),
-        };
-
-        let source = manager.get_source("nonexistent");
-        assert!(source.is_none());
     }
 
     #[test]
@@ -2588,30 +2392,5 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().unwrap().to_string();
         assert!(err.contains("repository context"));
-    }
-
-    #[test]
-    fn test_local_source_find_all_matches() {
-        let temp = TempDir::new().unwrap();
-        let repo_root = temp.path();
-
-        let overlays_dir = repo_root.join("my-overlays");
-        fs::create_dir_all(&overlays_dir).unwrap();
-        create_local_source_dir(&overlays_dir, &[("org", "repo", "overlay")]);
-
-        let sources = vec![Source {
-            name: "local".to_string(),
-            url: None,
-            path: Some(PathBuf::from("my-overlays")),
-        }];
-
-        let manager = SourceManager::new(sources, Some(repo_root)).unwrap();
-
-        let matches = manager
-            .find_all_matches("org", "repo", "overlay", None)
-            .unwrap();
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].0.name, "local");
-        assert_eq!(matches[0].1, ResolvedVia::Direct);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@
 //! Handles overlay state persistence, both in-repo (`.repoverlay/`) and external
 //! (`~/.local/share/repoverlay/`) for recovery after `git clean`.
 
-use crate::fs_util::atomic_write as atomic_write_impl;
+use crate::fs_util::atomic_write;
 use crate::overlay_name::OverlayName;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -123,24 +123,6 @@ impl OverlaySource {
         }
     }
 
-    /// Create a new overlay repository source.
-    #[allow(dead_code)] // Useful constructor for sources without resolution metadata
-    pub(crate) const fn overlay_repo(
-        org: String,
-        repo: String,
-        name: String,
-        commit: String,
-    ) -> Self {
-        Self::OverlayRepo {
-            org,
-            repo,
-            name,
-            commit,
-            resolved_via: None,
-            source_name: None,
-        }
-    }
-
     /// Create a new overlay repository source with full info (resolution + source name).
     pub(crate) const fn overlay_repo_full(
         org: String,
@@ -170,8 +152,56 @@ impl OverlaySource {
         matches!(self, Self::Library { .. })
     }
 
-    /// Get the library overlay name (for library sources only).
-    #[allow(dead_code)]
+    /// The source string (and optional ref override) that re-applies this
+    /// overlay through normal source resolution, e.g. for `restore`.
+    ///
+    /// For GitHub sources with a subpath, the subpath is rebuilt into a
+    /// `tree/HEAD/<subpath>` URL so resolution finds the specific overlay
+    /// instead of falling into browse/selection mode.
+    pub(crate) fn reapply_reference(&self) -> (String, Option<&str>) {
+        match self {
+            Self::Local { path, .. } => (path.to_string_lossy().to_string(), None),
+            Self::GitHub {
+                url,
+                owner,
+                repo,
+                git_ref,
+                subpath,
+                ..
+            } => {
+                let reference = subpath.as_ref().map_or_else(
+                    || url.clone(),
+                    |subpath| format!("https://github.com/{owner}/{repo}/tree/HEAD/{subpath}"),
+                );
+                (reference, Some(git_ref))
+            }
+            Self::OverlayRepo {
+                org, repo, name, ..
+            } => (format!("{org}/{repo}/{name}"), None),
+            Self::Library { name } => (name.clone(), None),
+        }
+    }
+}
+
+/// Test-only convenience helpers for constructing and inspecting sources.
+#[cfg(test)]
+impl OverlaySource {
+    pub(crate) const fn overlay_repo(
+        org: String,
+        repo: String,
+        name: String,
+        commit: String,
+    ) -> Self {
+        Self::OverlayRepo {
+            org,
+            repo,
+            name,
+            commit,
+            resolved_via: None,
+            source_name: None,
+        }
+    }
+
     pub(crate) fn library_name(&self) -> Option<&str> {
         match self {
             Self::Library { name } => Some(name),
@@ -179,8 +209,6 @@ impl OverlaySource {
         }
     }
 
-    /// Get a display string for the source.
-    #[allow(dead_code)]
     pub(crate) fn display(&self) -> String {
         match self {
             Self::Local { path, source_name } => source_name.as_ref().map_or_else(
@@ -224,56 +252,14 @@ impl OverlaySource {
         }
     }
 
-    /// Check if this is a GitHub source.
-    #[allow(dead_code)]
     pub(crate) const fn is_github(&self) -> bool {
         matches!(self, Self::GitHub { .. })
     }
 
-    /// Check if this is a local source.
-    #[allow(dead_code)]
-    pub(crate) const fn is_local(&self) -> bool {
-        matches!(self, Self::Local { .. })
-    }
-
-    /// Check if this is an overlay repository source.
-    #[allow(dead_code)]
     pub(crate) const fn is_overlay_repo(&self) -> bool {
         matches!(self, Self::OverlayRepo { .. })
     }
 
-    /// The source string (and optional ref override) that re-applies this
-    /// overlay through normal source resolution, e.g. for `restore`.
-    ///
-    /// For GitHub sources with a subpath, the subpath is rebuilt into a
-    /// `tree/HEAD/<subpath>` URL so resolution finds the specific overlay
-    /// instead of falling into browse/selection mode.
-    pub(crate) fn reapply_reference(&self) -> (String, Option<&str>) {
-        match self {
-            Self::Local { path, .. } => (path.to_string_lossy().to_string(), None),
-            Self::GitHub {
-                url,
-                owner,
-                repo,
-                git_ref,
-                subpath,
-                ..
-            } => {
-                let reference = subpath.as_ref().map_or_else(
-                    || url.clone(),
-                    |subpath| format!("https://github.com/{owner}/{repo}/tree/HEAD/{subpath}"),
-                );
-                (reference, Some(git_ref))
-            }
-            Self::OverlayRepo {
-                org, repo, name, ..
-            } => (format!("{org}/{repo}/{name}"), None),
-            Self::Library { name } => (name.clone(), None),
-        }
-    }
-
-    /// Get the local path for this source (for local sources only).
-    #[allow(dead_code)]
     pub(crate) fn local_path(&self) -> Option<&Path> {
         match self {
             Self::Local { path, .. } => Some(path),
@@ -282,7 +268,7 @@ impl OverlaySource {
     }
 }
 
-/// Abstraction for resolving overlay sources to local paths and querying capabilities.
+/// Source resolution and capability queries.
 ///
 /// Centralizes the `match` on `OverlaySource` variants so that each command
 /// doesn't need to independently handle source-type dispatch. Adding a new
@@ -290,41 +276,13 @@ impl OverlaySource {
 /// exhaustiveness via `match` ensures completeness).
 ///
 /// See: <https://github.com/tylerbutler/repoverlay/issues/149>
-pub(crate) trait SourceResolver {
+impl OverlaySource {
     /// Return the local filesystem path where this overlay's files live.
     ///
     /// - **Local**: the stored path directly.
     /// - **`OverlayRepo`**: the path within the cloned overlay repo (uses `source_name` when available).
     /// - **GitHub**: the cached download path.
-    fn resolve_local_path(&self) -> Result<PathBuf>;
-
-    /// Can files be written back to this source? (add/edit operations)
-    ///
-    /// - **Local**: `true` — files live on the local filesystem.
-    /// - **`OverlayRepo`**: `true` — files live in a cloned git repo.
-    /// - **GitHub**: `false` — cached read-only downloads.
-    fn is_mutable(&self) -> bool;
-
-    /// Can this source be synced with its upstream? (sync command)
-    ///
-    /// - **Local**: `false` — no upstream concept.
-    /// - **`OverlayRepo`**: `true` — can push changes to the overlay repo.
-    /// - **GitHub**: `false` — read-only cache.
-    fn is_syncable(&self) -> bool;
-
-    /// Can we check for newer versions? (update command)
-    ///
-    /// - **Local**: `false` — always uses the current local files.
-    /// - **`OverlayRepo`**: `true` — can pull newer commits.
-    /// - **GitHub**: `true` — can re-fetch from GitHub.
-    fn is_updatable(&self) -> bool;
-
-    /// Human-readable description of the source type for messages.
-    fn source_type_label(&self) -> &'static str;
-}
-
-impl SourceResolver for OverlaySource {
-    fn resolve_local_path(&self) -> Result<PathBuf> {
+    pub(crate) fn resolve_local_path(&self) -> Result<PathBuf> {
         match self {
             Self::Local { path, .. } => Ok(path.clone()),
             Self::Library { name } => {
@@ -375,28 +333,44 @@ impl SourceResolver for OverlaySource {
         }
     }
 
-    fn is_mutable(&self) -> bool {
+    /// Can files be written back to this source? (add/edit operations)
+    ///
+    /// - **Local**: `true` — files live on the local filesystem.
+    /// - **`OverlayRepo`**: `true` — files live in a cloned git repo.
+    /// - **GitHub**: `false` — cached read-only downloads.
+    pub(crate) const fn is_mutable(&self) -> bool {
         match self {
             Self::Local { .. } | Self::Library { .. } | Self::OverlayRepo { .. } => true,
             Self::GitHub { .. } => false,
         }
     }
 
-    fn is_syncable(&self) -> bool {
+    /// Can this source be synced with its upstream? (sync command)
+    ///
+    /// - **Local**: `false` — no upstream concept.
+    /// - **`OverlayRepo`**: `true` — can push changes to the overlay repo.
+    /// - **GitHub**: `false` — read-only cache.
+    pub(crate) const fn is_syncable(&self) -> bool {
         match self {
             Self::OverlayRepo { .. } => true,
             Self::Local { .. } | Self::Library { .. } | Self::GitHub { .. } => false,
         }
     }
 
-    fn is_updatable(&self) -> bool {
+    /// Can we check for newer versions? (update command)
+    ///
+    /// - **Local**: `false` — always uses the current local files.
+    /// - **`OverlayRepo`**: `true` — can pull newer commits.
+    /// - **GitHub**: `true` — can re-fetch from GitHub.
+    pub(crate) const fn is_updatable(&self) -> bool {
         match self {
             Self::OverlayRepo { .. } | Self::GitHub { .. } => true,
             Self::Local { .. } | Self::Library { .. } => false,
         }
     }
 
-    fn source_type_label(&self) -> &'static str {
+    /// Human-readable description of the source type for messages.
+    pub(crate) const fn source_type_label(&self) -> &'static str {
         match self {
             Self::Local { .. } => "local",
             Self::Library { .. } => "library",
@@ -602,10 +576,6 @@ pub(crate) fn external_state_dir_for_target(target: &Path) -> Result<PathBuf> {
     let base = external_state_dir()?;
     let target_hash = hash_path(target);
     Ok(base.join(target_hash))
-}
-
-pub(crate) fn atomic_write(path: &Path, content: &str) -> Result<()> {
-    atomic_write_impl(path, content)
 }
 
 /// Save overlay state to the external backup location.
@@ -1967,7 +1937,7 @@ directories =
         assert!(removed.is_none());
     }
 
-    // ==================== SourceResolver trait tests ====================
+    // ==================== Source resolution tests ====================
 
     #[test]
     fn source_resolver_local_is_mutable() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -14,8 +14,8 @@ use crate::canonicalize_path;
 use crate::github::GitHubSource;
 use crate::remove_single_overlay;
 use crate::state::{
-    OVERLAYS_DIR, OverlaySource, STATE_DIR, SourceResolver, list_applied_overlays,
-    load_overlay_state, normalize_overlay_name,
+    OVERLAYS_DIR, OverlaySource, STATE_DIR, list_applied_overlays, load_overlay_state,
+    normalize_overlay_name,
 };
 
 /// Update applied overlays from remote sources.

--- a/src/widgets/multi_select_tree.rs
+++ b/src/widgets/multi_select_tree.rs
@@ -65,48 +65,9 @@ impl<Id: Clone + Eq + Hash> MultiSelectTreeState<Id> {
         self.selected.contains(id)
     }
 
-    /// Toggle selection of a single item.
-    #[allow(dead_code)]
-    pub(crate) fn toggle(&mut self, id: &Id) {
-        if self.selected.contains(id) {
-            self.selected.remove(id);
-        } else {
-            self.selected.insert(id.clone());
-        }
-    }
-
     /// Select a single item.
     pub(crate) fn select(&mut self, id: Id) {
         self.selected.insert(id);
-    }
-
-    /// Select multiple items.
-    #[allow(dead_code)]
-    pub(crate) fn select_many(&mut self, ids: impl IntoIterator<Item = Id>) {
-        self.selected.extend(ids);
-    }
-
-    /// Deselect multiple items.
-    #[allow(dead_code)]
-    pub(crate) fn deselect_many<'a>(&mut self, ids: impl IntoIterator<Item = &'a Id>)
-    where
-        Id: 'a,
-    {
-        for id in ids {
-            self.selected.remove(id);
-        }
-    }
-
-    /// Get the number of selected items.
-    #[allow(dead_code)]
-    pub(crate) fn selected_count(&self) -> usize {
-        self.selected.len()
-    }
-
-    /// Get an iterator over selected identifiers.
-    #[allow(dead_code)]
-    pub(crate) fn selected_ids(&self) -> impl Iterator<Item = &Id> {
-        self.selected.iter()
     }
 
     /// Clear all selections.
@@ -213,13 +174,6 @@ impl<'a, Id: Clone + Eq + Hash + 'a> MultiSelectTree<'a, Id> {
     /// Set the function used to compute descendant IDs for tri-state checkboxes.
     pub(crate) fn descendants_fn(mut self, f: DescendantsFn<'a, Id>) -> Self {
         self.descendants_fn = Some(f);
-        self
-    }
-
-    /// Set the highlight style for the focused node.
-    #[allow(dead_code)]
-    pub(crate) const fn highlight_style(mut self, style: Style) -> Self {
-        self.highlight_style = style;
         self
     }
 
@@ -335,16 +289,6 @@ mod tests {
     }
 
     #[test]
-    fn toggle_leaf_selection() {
-        let mut state = MultiSelectTreeState::<String>::default();
-        assert!(!state.is_selected(&"child-a".to_string()));
-        state.toggle(&"child-a".to_string());
-        assert!(state.is_selected(&"child-a".to_string()));
-        state.toggle(&"child-a".to_string());
-        assert!(!state.is_selected(&"child-a".to_string()));
-    }
-
-    #[test]
     fn check_state_all_selected() {
         let mut state = MultiSelectTreeState::<String>::default();
         state.select("child-a".to_string());
@@ -375,21 +319,13 @@ mod tests {
     }
 
     #[test]
-    fn select_many_and_deselect_many() {
-        let mut state = MultiSelectTreeState::<String>::default();
-        state.select_many(["a".to_string(), "b".to_string(), "c".to_string()]);
-        assert_eq!(state.selected_count(), 3);
-        state.deselect_many(&["a".to_string(), "b".to_string()]);
-        assert_eq!(state.selected_count(), 1);
-        assert!(state.is_selected(&"c".to_string()));
-    }
-
-    #[test]
     fn clear_selection() {
         let mut state = MultiSelectTreeState::<String>::default();
-        state.select_many(["a".to_string(), "b".to_string()]);
+        state.select("a".to_string());
+        state.select("b".to_string());
         state.clear_selection();
-        assert_eq!(state.selected_count(), 0);
+        assert!(!state.is_selected(&"a".to_string()));
+        assert!(!state.is_selected(&"b".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Applies the findings of an over-engineering audit: **−857 lines, −2 dependencies**, with no behavior changes beyond plainer confirm/input prompt rendering.

### Dead code sweep
- Stripped all 49 stale `#[allow(dead_code)]` annotations and deleted what the compiler then confirmed dead:
  - `GitRef::Tag` variant (never constructed) and its unreachable match arms in `cache.rs`
  - `cache_key`, `display_url`, `is_default`, `sanitize_for_path` in `github.rs` (used only by their own tests)
  - `parse_overlay_reference` ("kept for backward compatibility" in a crate with no external API)
  - `validate_path_component` in `path_safety.rs` (dead duplicate of the live copy in `overlay_repo.rs`)
  - `Source::is_git`/`Source::validate`, `needs_local_path_warning`, `get_source`/`find_all_matches`, unread `CachedOverlay.cached_at`, and six unused tree-widget methods
- `OverlaySource` helpers used only by tests (~49 call sites) moved into a `#[cfg(test)] impl` instead of being deleted — out of the shipped binary, test coverage intact
- `ProfileContext.harness_home`/`session_id` kept with targeted allows: the `REPOVERLAY_*_HOME` override they plumb is documented in DEV.md and exercised throughout `tests/cli.rs`

### Simplification
- Single-impl `SourceResolver` trait converted to inherent methods on `OverlaySource` (docs preserved; trait import removed from six files)
- Delegate-only wrappers removed: `state::atomic_write`, `edit_overlay` → `interactive_edit_overlay` pass-through, `resolve_overlay_source_path` (the #142/#147 regression tests now call `resolve_local_path()` directly)

### Dependencies
- `dialoguer` → 37-line stdin `confirm`/`input` helper (`src/prompt.rs`); all three call sites were already interactivity-guarded
- `dirs` → `std::env::home_dir()` (un-deprecated as of Rust 1.87; toolchain pins 1.91)

## Test plan

- `cargo test`: 1,314 lib + 245 integration tests pass
- `cargo clippy --all-targets` clean at the repo's pedantic+nursery level; `cargo fmt --check` clean
- One insta snapshot updated as a consequence of deleting `GitRef::Tag` (`snapshot_git_ref_display` loses its `tag:v1.2.3` line)