### PR TITLE
fix: resolve ephemeral repo root from subdirectories

### DIFF
--- a/.changes/unreleased/Fixed-20260723-180736.yaml
+++ b/.changes/unreleased/Fixed-20260723-180736.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    Resolve ephemeral harness targets from repository subdirectories
+
+    `repoverlay copilot` and `repoverlay claude` now find the enclosing repository root when `--target` is omitted.
+time: 2026-07-23T18:07:36-07:00

--- a/src/cli/commands/copilot.rs
+++ b/src/cli/commands/copilot.rs
@@ -11,6 +11,8 @@ use std::os::unix::process::ExitStatusExt;
 use crate::profile::ProfileMode;
 use crate::profile_applicators::AgentHarness;
 
+use super::find_repo_root;
+
 struct ProfileRunLock {
     path: PathBuf,
 }
@@ -116,8 +118,10 @@ pub(crate) fn run_ephemeral_profiles(
     extra_args: Vec<String>,
 ) -> Result<()> {
     let label = harness.label();
-    let target = target.unwrap_or_else(|| PathBuf::from("."));
-    let target = crate::canonicalize_path(&target, "Target")?;
+    let target = match target {
+        Some(target) => crate::canonicalize_path(&target, "Target")?,
+        None => find_repo_root()?,
+    };
     crate::validate_git_repo(&target)?;
 
     // Reject duplicate names up front; otherwise the second apply of the same

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -485,7 +485,7 @@ enum Commands {
         #[arg(long = "profile", required = true)]
         profiles: Vec<String>,
 
-        /// Target repository directory (defaults to current directory)
+        /// Target repository directory (defaults to enclosing repository root)
         #[arg(short, long)]
         target: Option<PathBuf>,
 
@@ -500,7 +500,7 @@ enum Commands {
         #[arg(long = "profile", required = true)]
         profiles: Vec<String>,
 
-        /// Target repository directory (defaults to current directory)
+        /// Target repository directory (defaults to enclosing repository root)
         #[arg(short, long)]
         target: Option<PathBuf>,
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1260,6 +1260,55 @@ profiles =
 }
 
 #[test]
+fn copilot_profile_resolves_repo_root_from_subdirectory() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+    let copilot_home = tempfile::TempDir::new().unwrap();
+    let leaf = ctx.repo_path().join("deep/leaf");
+    let marker = ctx.repo_path().join("copilot-working-dir.txt");
+    fs::create_dir_all(&leaf).unwrap();
+    ctx.create_repo_file(".repoverlay/copilot-instructions.md", "Use Rust 2024.");
+    ctx.write_repo_config(
+        r"
+profiles =
+  rust-dev =
+    instructions =
+      =
+        source = copilot-instructions.md
+",
+    );
+
+    cargo_bin_cmd!("repoverlay")
+        .args([
+            "copilot",
+            "--profile",
+            "rust-dev",
+            "--",
+            "-c",
+            &format!("pwd > {}", marker.display()),
+        ])
+        .current_dir(&leaf)
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("REPOVERLAY_COPILOT_HOME", copilot_home.path())
+        .env("REPOVERLAY_COPILOT_COMMAND", "sh")
+        .env("REPOVERLAY_NO_UPDATE_CHECK", "1")
+        .assert()
+        .success();
+
+    let working_dir = fs::read_to_string(marker).unwrap();
+    assert_eq!(
+        fs::canonicalize(working_dir.trim()).unwrap(),
+        fs::canonicalize(ctx.repo_path()).unwrap()
+    );
+    assert!(!ctx.repo_path().join("AGENTS.md").exists());
+    assert!(
+        !ctx.repo_path()
+            .join(".repoverlay/profiles/rust-dev.copilot.ccl")
+            .exists()
+    );
+}
+
+#[test]
 fn copilot_runs_multiple_profiles_and_cleans_up_all() {
     let ctx = TestContext::new();
     let config_dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- resolve the enclosing repository root when Copilot or Claude runs without `--target`
- preserve explicit target validation behavior
- add regression coverage for launching Copilot from a nested leaf directory

## Testing

- `just check`

Closes #390
