### PR TITLE
fix(cache): manage configured source clones

### DIFF
--- a/.changes/unreleased/cache-Fixed-20260723-193024.yaml
+++ b/.changes/unreleased/cache-Fixed-20260723-193024.yaml
@@ -1,0 +1,8 @@
+component: cache
+kind: Fixed
+body: |-
+  Clarify cache commands for configured-source clones.
+  `cache list` now shows configured-source clones separately. Targeted
+  `--source` removal and combined `--all` clearing manage those clones
+  alongside GitHub caches.
+time: 2026-07-23T19:30:24.623018-07:00

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -201,6 +201,9 @@ Examples: repoverlay create my-overlay              # Detects org/repo from git 
 * `-o`, `--output <OUTPUT>` — Output directory for local overlay creation (no overlay repo required)
 * `--into <DEST>` — Create the overlay directly into a destination ("library")
 * `--no-apply` — Skip applying the overlay after creating into the library
+* `--global` — Create a global overlay (applies to any repository)
+
+   Scaffolds into the `@global/<name>/` namespace of the overlay repo instead of `org/repo/<name>/`, skipping git-remote target detection.
 * `--dry-run` — Show what would be created without creating files
 * `-y`, `--yes` — Skip interactive prompts, use defaults
 * `-f`, `--force` — Force overwrite if overlay already exists
@@ -267,15 +270,15 @@ Manage the overlay cache
 
 ### Subcommands
 
-* `list` — List cached repositories
-* `remove` — Remove cached repositories
+* `list` — List cached GitHub repositories and configured-source clones
+* `remove` — Remove cached GitHub repositories and configured-source clones
 * `path` — Show cache location
 
 
 
 ## `repoverlay cache list`
 
-List cached repositories
+List cached GitHub repositories and configured-source clones
 
 **Usage:** `repoverlay cache list`
 
@@ -283,18 +286,19 @@ List cached repositories
 
 ## `repoverlay cache remove`
 
-Remove cached repositories
+Remove cached GitHub repositories and configured-source clones
 
 **Usage:** `repoverlay cache remove [OPTIONS] [REPO]`
 
 ### Arguments
 
-* `<REPO>` — Repository to remove (format: owner/repo)
+* `<REPO>` — Cached GitHub repository to remove (format: owner/repo)
 
 ### Options
 
-* `-a`, `--all` — Remove all cached repositories
-* `-y`, `--yes` — Skip confirmation prompt (used with --all)
+* `--source <SOURCE>` — Cached source clone to remove by source name
+* `-a`, `--all` — Remove all cached GitHub repositories and configured-source clones
+* `-y`, `--yes` — Skip confirmation prompt when removing all cache entries
 
 
 
@@ -533,7 +537,7 @@ Manage repository profiles
 
 **Usage:** `repoverlay profile <COMMAND>`
 
-###### **Subcommands:**
+### Subcommands
 
 * `list` — List configured profiles
 * `show` — Show a configured profile
@@ -543,13 +547,13 @@ Manage repository profiles
 
 
 
-
 ## `repoverlay profile list`
+
 List configured profiles
 
 **Usage:** `repoverlay profile list [OPTIONS]`
 
-###### **Options:**
+### Options
 
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 
@@ -561,11 +565,11 @@ Show a configured profile
 
 **Usage:** `repoverlay profile show [OPTIONS] <NAME>`
 
-###### **Arguments:**
+### Arguments
 
 * `<NAME>` — Profile name
 
-###### **Options:**
+### Options
 
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 
@@ -577,11 +581,11 @@ Apply a profile persistently
 
 **Usage:** `repoverlay profile apply [OPTIONS] --harness <HARNESS> <NAME>`
 
-###### **Arguments:**
+### Arguments
 
 * `<NAME>` — Profile name
 
-###### **Options:**
+### Options
 
 * `--harness <HARNESS>`
 
@@ -597,7 +601,7 @@ Show applied profile state
 
 **Usage:** `repoverlay profile status [OPTIONS]`
 
-###### **Options:**
+### Options
 
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
 * `--harness <HARNESS>`
@@ -613,11 +617,11 @@ Remove an applied profile
 
 **Usage:** `repoverlay profile remove [OPTIONS] --harness <HARNESS> <NAME>`
 
-###### **Arguments:**
+### Arguments
 
 * `<NAME>` — Profile name
 
-###### **Options:**
+### Options
 
 * `--harness <HARNESS>`
 
@@ -712,11 +716,11 @@ Run GitHub Copilot with one or more profiles applied for the process lifetime
 
 **Usage:** `repoverlay copilot [OPTIONS] --profile <PROFILES> [-- <EXTRA_ARGS>...]`
 
-###### **Arguments:**
+### Arguments
 
 * `<EXTRA_ARGS>` — Extra arguments forwarded to the Copilot harness
 
-###### **Options:**
+### Options
 
 * `--profile <PROFILES>` — Profile name to apply while Copilot runs (repeat to apply several)
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)
@@ -729,11 +733,11 @@ Run Claude with one or more profiles applied for the process lifetime
 
 **Usage:** `repoverlay claude [OPTIONS] --profile <PROFILES> [-- <EXTRA_ARGS>...]`
 
-###### **Arguments:**
+### Arguments
 
 * `<EXTRA_ARGS>` — Extra arguments forwarded to the Claude harness
 
-###### **Options:**
+### Options
 
 * `--profile <PROFILES>` — Profile name to apply while Claude runs (repeat to apply several)
 * `-t`, `--target <TARGET>` — Target repository directory (defaults to current directory)

--- a/docs/manual-tests/cache.md
+++ b/docs/manual-tests/cache.md
@@ -6,7 +6,27 @@
 
 ## Setup
 
-No special setup is needed — cache commands operate on the global cache directory.
+Use an isolated root for both config and cache.
+
+```bash
+ORIG_PWD="$PWD"
+TEST_ROOT="$(mktemp -d "$PWD/.manual-cache-test.XXXXXX")" || exit 1
+cleanup() {
+  trap - EXIT
+  cd "$ORIG_PWD" || exit 1
+  rm -rf -- "$TEST_ROOT"
+  unset XDG_CONFIG_HOME REPOVERLAY_CACHE_DIR ORIG_PWD TEST_ROOT DEMO_SOURCE_URL DEMO_SOURCE_NAME RETENTION_SOURCE_URL RETENTION_SOURCE_NAME CACHE_OUTPUT
+  unset -f cleanup
+}
+
+export TEST_ROOT ORIG_PWD
+mkdir -p "$TEST_ROOT/config" "$TEST_ROOT/cache" "$TEST_ROOT/repo"
+export XDG_CONFIG_HOME="$TEST_ROOT/config"
+export REPOVERLAY_CACHE_DIR="$TEST_ROOT/cache"
+cd "$TEST_ROOT/repo"
+git init >/dev/null || exit 1
+trap cleanup EXIT
+```
 
 ## Test Cases
 
@@ -20,106 +40,165 @@ repoverlay cache path
 
 **Expected Output:**
 
-- Prints the absolute path to the cache directory (e.g., `~/.cache/repoverlay`)
+- Prints the absolute cache path
+- Matches `$REPOVERLAY_CACHE_DIR`
 
-**Verify:**
-
-```bash
-CACHE_PATH=$(repoverlay cache path)
-echo "$CACHE_PATH"
-# Should be a valid absolute path
-# Path should end with "repoverlay" or similar
-```
-
-### TC-02: List cached repositories (empty cache)
+### TC-02: List cached namespaces
 
 **Steps:**
 
 ```bash
-repoverlay cache list
+mkdir -p "$REPOVERLAY_CACHE_DIR/github/OWNER/REPO"
+mkdir -p "$REPOVERLAY_CACHE_DIR/sources/overlay"
+
+CACHE_OUTPUT=$(repoverlay cache list)
+printf '%s\n' "$CACHE_OUTPUT"
 ```
 
 **Expected Output:**
 
-- Message indicating no cached repositories, or an empty list
+- Shows separate `GitHub repositories` and `Configured source clones` sections
+- Lists `OWNER/REPO` and `overlay` under the correct section
 
-**Verify:**
+### TC-03 (Optional, requires network): Create and locate a configured source clone
+
+Set these before running the networked cases:
 
 ```bash
-repoverlay cache list
-echo "Exit code: $?"
-# Exit code should be 0 (not an error to have an empty cache)
+: "${DEMO_SOURCE_URL:?Set DEMO_SOURCE_URL to a real public overlay source repo before TC-03}"
+case "$DEMO_SOURCE_URL" in
+  *OWNER/REPO*|https://example.com/*)
+    echo "Set DEMO_SOURCE_URL to a real public overlay source repo before TC-03." >&2
+    exit 1
+    ;;
+esac
 ```
-
-### TC-03: Remove with --all on empty cache
 
 **Steps:**
 
 ```bash
+DEMO_SOURCE_NAME="network-source"
+repoverlay source add "$DEMO_SOURCE_URL" --name "$DEMO_SOURCE_NAME"
+repoverlay browse --no-interactive
+CACHE_OUTPUT=$(repoverlay cache list)
+printf '%s\n' "$CACHE_OUTPUT"
+```
+
+**Expected Output:**
+
+- A source-resolving command creates the configured-source clone
+- `cache list` shows `network-source` under `Configured source clones`
+
+### TC-04: Remove a cached configured source clone
+
+**Steps:**
+
+```bash
+mkdir -p "$REPOVERLAY_CACHE_DIR/sources/overlay"
+repoverlay cache remove --source overlay
+```
+
+**Expected Output:**
+
+- `Removed configured source clone overlay from cache.`
+
+### TC-05: Remove a missing configured source clone
+
+**Steps:**
+
+```bash
+repoverlay cache remove --source missing
+```
+
+**Expected Output:**
+
+- `Configured source clone missing is not cached.`
+
+### TC-06: Remove all cached namespaces with confirmation
+
+**Steps:**
+
+```bash
+mkdir -p "$REPOVERLAY_CACHE_DIR/github/OWNER/REPO"
+mkdir -p "$REPOVERLAY_CACHE_DIR/sources/overlay"
+
+repoverlay cache remove --all
+```
+
+**Expected Output:**
+
+- Prompt: `Remove all cached GitHub repositories and configured source clones? [y/N]`
+- Entering `n` prints the cancellation message and removes nothing
+
+### TC-07: Remove all cached namespaces without prompting
+
+**Steps:**
+
+```bash
+rm -rf "$REPOVERLAY_CACHE_DIR"
+mkdir -p "$REPOVERLAY_CACHE_DIR/github/OWNER/REPO"
+mkdir -p "$REPOVERLAY_CACHE_DIR/sources/overlay"
+
 repoverlay cache remove --all --yes
-echo "Exit code: $?"
 ```
 
 **Expected Output:**
 
-- Message indicating cache cleared or no cached repositories to remove
-- Exit code 0
+- Removes exactly 1 GitHub repository and 1 configured source clone
+- Example: `Removed 1 GitHub repository(s) and 1 configured source clone(s).`
 
-### TC-04 (Optional, requires network): Cache populated after GitHub apply
+### TC-08: Repo-local path sources do not create cache entries
 
 **Steps:**
 
 ```bash
-TEST_DIR=$(mktemp -d)
-cd "$TEST_DIR"
-
-mkdir target-repo && cd target-repo
-git init
-git commit --allow-empty -m "init"
-cd "$TEST_DIR"
-
-# Replace with a real public overlay repository URL
-repoverlay apply https://github.com/OWNER/REPO --target ./target-repo
-
-repoverlay cache list
+mkdir -p "$PWD/overlays/local-src"
+repoverlay source add "$PWD/overlays/local-src" --name local-src
+repoverlay source list
+CACHE_OUTPUT=$(repoverlay cache list)
+printf '%s\n' "$CACHE_OUTPUT"
+if printf '%s\n' "$CACHE_OUTPUT" | grep -q 'local-src'; then
+  echo "unexpected cache entry for local-src" >&2
+  exit 1
+fi
 ```
 
 **Expected Output:**
 
-- Cache list shows the cloned GitHub repository
-- Displays owner/repo, ref, commit hash, and fetched timestamp
+- `source list` includes `local-src`
+- `cache list` shows no new configured-source clone for `local-src`
 
-**Verify:**
-
-```bash
-CACHE_PATH=$(repoverlay cache path)
-ls "$CACHE_PATH"
-# Should contain a directory for the cached repository
-```
-
-### TC-05 (Optional, requires network): Remove specific cached repository
+### TC-09: Removing a configured Git source from config leaves its cache entry
 
 **Steps:**
 
 ```bash
-# Assumes TC-04 has populated the cache with OWNER/REPO
-repoverlay cache remove OWNER/REPO
+RETENTION_SOURCE_URL="https://example.invalid/retention/repo"
+RETENTION_SOURCE_NAME="retention-source"
+
+repoverlay source add "$RETENTION_SOURCE_URL" --name "$RETENTION_SOURCE_NAME"
+mkdir -p "$REPOVERLAY_CACHE_DIR/sources/$RETENTION_SOURCE_NAME"
+
+repoverlay source remove "$RETENTION_SOURCE_NAME"
+CACHE_OUTPUT=$(repoverlay cache list)
+printf '%s\n' "$CACHE_OUTPUT"
+printf '%s\n' "$CACHE_OUTPUT" | grep -q "$RETENTION_SOURCE_NAME"
+repoverlay cache remove --source "$RETENTION_SOURCE_NAME"
+CACHE_OUTPUT=$(repoverlay cache list)
+printf '%s\n' "$CACHE_OUTPUT"
+if printf '%s\n' "$CACHE_OUTPUT" | grep -q "$RETENTION_SOURCE_NAME"; then
+  echo "unexpected cache entry for $RETENTION_SOURCE_NAME" >&2
+  exit 1
+fi
 ```
 
 **Expected Output:**
 
-- Success message indicating the repository was removed from cache
-
-**Verify:**
-
-```bash
-repoverlay cache list
-# Should no longer show the removed repository
-```
+- `source remove` succeeds but the cached clone remains listed
+- `cache remove --source retention-source` removes the cached clone
 
 ## Cleanup
 
 ```bash
-# Only if TC-04/TC-05 were run
-rm -rf "$TEST_DIR"
+cleanup
 ```

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-//! Cache management for GitHub repository overlays.
+//! Cache management for GitHub repository overlays and configured sources.
 //!
 //! Handles downloading, caching, and updating GitHub repositories for use as overlays.
 
@@ -7,11 +7,13 @@ use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use crate::github::{GitHubSource, GitRef};
+use crate::path_safety::validate_path_component;
 
 /// Execute a git command in a directory and return the output.
 fn git_in_dir(repo_path: &Path, args: &[&str]) -> Result<Output> {
@@ -74,10 +76,74 @@ pub(crate) struct CachedRepoInfo {
     pub(crate) meta: Option<CacheMeta>,
 }
 
+/// Information about a cached configured source.
+#[derive(Debug)]
+pub(crate) struct CachedSourceInfo {
+    /// Source name.
+    #[allow(dead_code)] // Consumed by the next cache CLI task.
+    pub(crate) name: String,
+    /// Path to the cached source.
+    #[allow(dead_code)] // Consumed by the next cache CLI task.
+    pub(crate) path: PathBuf,
+}
+
+/// Counts returned when clearing cache namespaces.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CacheClearCounts {
+    /// Number of cached GitHub repositories removed.
+    pub(crate) github: usize,
+    /// Number of cached configured sources removed.
+    #[allow(dead_code)] // Reported once the cache CLI displays both namespace counts.
+    pub(crate) sources: usize,
+}
+
 /// Manager for the overlay cache.
 #[derive(Debug, Clone)]
 pub(crate) struct CacheManager {
     cache_dir: PathBuf,
+}
+
+/// Parse and validate a cache directory override.
+pub(crate) fn parse_cache_dir_override(value: Option<&OsStr>) -> Result<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    if value.is_empty() {
+        bail!("REPOVERLAY_CACHE_DIR cannot be empty");
+    }
+
+    let path = Path::new(value);
+    if !path.is_absolute() {
+        bail!("REPOVERLAY_CACHE_DIR must be an absolute path");
+    }
+
+    Ok(Some(path.to_path_buf()))
+}
+
+/// Get the default cache directory from platform conventions.
+pub(crate) fn default_cache_dir() -> Result<PathBuf> {
+    let proj_dirs = ProjectDirs::from("", "", "repoverlay")
+        .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
+
+    Ok(proj_dirs.cache_dir().to_path_buf())
+}
+
+/// Get the cache directory.
+pub(crate) fn cache_dir() -> Result<PathBuf> {
+    if let Some(dir) =
+        parse_cache_dir_override(std::env::var_os("REPOVERLAY_CACHE_DIR").as_deref())?
+    {
+        return Ok(dir);
+    }
+
+    default_cache_dir()
+}
+
+/// Build a configured-source cache path beneath a cache root.
+pub(crate) fn configured_source_cache_path(cache_root: &Path, name: &str) -> Result<PathBuf> {
+    validate_path_component(name)?;
+    Ok(cache_root.join("sources").join(name))
 }
 
 #[allow(clippy::unused_self)]
@@ -101,7 +167,7 @@ impl CacheManager {
         source: &GitHubSource,
         update: bool,
     ) -> Result<CachedOverlay> {
-        let repo_path = self.repo_path(source);
+        let repo_path = self.repo_path(source)?;
         let owner = &source.owner;
         let repo = &source.repo;
         let git_ref = source.git_ref.as_str();
@@ -147,11 +213,19 @@ impl CacheManager {
     }
 
     /// Get the path where a repository would be cached.
-    pub(crate) fn repo_path(&self, source: &GitHubSource) -> PathBuf {
-        self.cache_dir
-            .join("github")
-            .join(&source.owner)
-            .join(&source.repo)
+    pub(crate) fn repo_path(&self, source: &GitHubSource) -> Result<PathBuf> {
+        self.github_cache_path(&source.owner, &source.repo)
+    }
+
+    /// Get the path where a configured source would be cached.
+    fn source_path(&self, name: &str) -> Result<PathBuf> {
+        configured_source_cache_path(&self.cache_dir, name)
+    }
+
+    fn github_cache_path(&self, owner: &str, repo: &str) -> Result<PathBuf> {
+        validate_path_component(owner)?;
+        validate_path_component(repo)?;
+        Ok(self.cache_dir.join("github").join(owner).join(repo))
     }
 
     /// Clone a repository.
@@ -314,11 +388,49 @@ impl CacheManager {
         None
     }
 
+    fn remove_path(path: &Path) -> Result<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_dir() => {
+                fs::remove_dir_all(path)?;
+                Ok(true)
+            }
+            Ok(_) => {
+                fs::remove_file(path)?;
+                Ok(true)
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn require_real_directory(path: &Path, label: &str) -> Result<bool> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_dir() => Ok(true),
+            Ok(_) => bail!("{label} is not a directory"),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn prune_empty_dir(path: &Path) -> Result<()> {
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+
+        if metadata.is_dir() && path.read_dir()?.next().is_none() {
+            fs::remove_dir(path)?;
+        }
+
+        Ok(())
+    }
+
     /// List all cached repositories.
     pub(crate) fn list_cached(&self) -> Result<Vec<CachedRepoInfo>> {
         let github_dir = self.cache_dir.join("github");
 
-        if !github_dir.exists() {
+        if !github_dir.is_dir() {
             return Ok(Vec::new());
         }
 
@@ -356,46 +468,115 @@ impl CacheManager {
         Ok(repos)
     }
 
-    /// Remove a specific cached repository.
-    pub(crate) fn remove_cached(&self, owner: &str, repo: &str) -> Result<bool> {
-        let path = self.cache_dir.join("github").join(owner).join(repo);
+    /// List all cached configured sources.
+    pub(crate) fn list_cached_sources(&self) -> Result<Vec<CachedSourceInfo>> {
+        let sources_dir = self.cache_dir.join("sources");
 
-        if path.exists() {
-            fs::remove_dir_all(&path)?;
+        if !sources_dir.is_dir() {
+            return Ok(Vec::new());
+        }
 
-            // Clean up empty parent directories
-            let owner_dir = self.cache_dir.join("github").join(owner);
-            if owner_dir.exists() && owner_dir.read_dir()?.next().is_none() {
-                fs::remove_dir(&owner_dir)?;
+        let mut sources = Vec::new();
+
+        for source_entry in fs::read_dir(&sources_dir)? {
+            let source_entry = source_entry?;
+            if !source_entry.file_type()?.is_dir() {
+                continue;
             }
 
-            Ok(true)
-        } else {
-            Ok(false)
+            sources.push(CachedSourceInfo {
+                name: source_entry.file_name().to_string_lossy().to_string(),
+                path: source_entry.path(),
+            });
         }
+
+        sources.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(sources)
+    }
+
+    /// Remove a specific cached repository.
+    pub(crate) fn remove_cached(&self, owner: &str, repo: &str) -> Result<bool> {
+        validate_path_component(owner)?;
+        validate_path_component(repo)?;
+
+        if !Self::require_real_directory(&self.cache_dir, "cache root")? {
+            return Ok(false);
+        }
+
+        let github_dir = self.cache_dir.join("github");
+        if !Self::require_real_directory(&github_dir, "cache github namespace")? {
+            return Ok(false);
+        }
+
+        let owner_dir = github_dir.join(owner);
+        if !Self::require_real_directory(&owner_dir, "cache github owner")? {
+            return Ok(false);
+        }
+
+        let path = owner_dir.join(repo);
+
+        if !Self::remove_path(&path)? {
+            return Ok(false);
+        }
+
+        // Clean up empty parent directories.
+        Self::prune_empty_dir(&owner_dir)?;
+
+        Ok(true)
+    }
+
+    /// Remove a specific cached configured source.
+    pub(crate) fn remove_cached_source(&self, name: &str) -> Result<bool> {
+        validate_path_component(name)?;
+
+        if !Self::require_real_directory(&self.cache_dir, "cache root")? {
+            return Ok(false);
+        }
+
+        let sources_dir = self.cache_dir.join("sources");
+        if !Self::require_real_directory(&sources_dir, "cache sources namespace")? {
+            return Ok(false);
+        }
+
+        let path = self.source_path(name)?;
+
+        if !Self::remove_path(&path)? {
+            return Ok(false);
+        }
+
+        // Clean up empty parent directories.
+        let sources_dir = self.cache_dir.join("sources");
+        Self::prune_empty_dir(&sources_dir)?;
+
+        Ok(true)
     }
 
     /// Clear the entire cache.
-    pub(crate) fn clear_cache(&self) -> Result<usize> {
-        let github_dir = self.cache_dir.join("github");
-
-        if !github_dir.exists() {
-            return Ok(0);
+    pub(crate) fn clear_cache(&self) -> Result<CacheClearCounts> {
+        if !Self::require_real_directory(&self.cache_dir, "cache root")? {
+            return Ok(CacheClearCounts::default());
         }
 
-        let repos = self.list_cached()?;
-        let count = repos.len();
+        let counts = CacheClearCounts {
+            github: self.list_cached()?.len(),
+            sources: self.list_cached_sources()?.len(),
+        };
 
-        fs::remove_dir_all(&github_dir)?;
+        let github_dir = self.cache_dir.join("github");
+        let sources_dir = self.cache_dir.join("sources");
 
-        Ok(count)
+        Self::remove_path(&github_dir)?;
+        Self::remove_path(&sources_dir)?;
+
+        Ok(counts)
     }
 
     /// Check for updates to a cached repository.
     ///
     /// Returns the latest commit on the default branch if different from current.
     pub(crate) fn check_for_updates(&self, source: &GitHubSource) -> Result<Option<String>> {
-        let repo_path = self.repo_path(source);
+        let repo_path = self.repo_path(source)?;
 
         if !repo_path.exists() {
             return Ok(None);
@@ -441,17 +622,13 @@ impl CacheManager {
 }
 
 /// Get the cache directory.
-pub(crate) fn cache_dir() -> Result<PathBuf> {
-    let proj_dirs = ProjectDirs::from("", "", "repoverlay")
-        .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
-
-    Ok(proj_dirs.cache_dir().to_path_buf())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs as unix_fs;
 
     /// Run a git command in `repo`, asserting success.
     fn git_ok(repo: &Path, args: &[&str]) {
@@ -515,7 +692,7 @@ mod tests {
     fn test_repo_path() {
         let manager = CacheManager::new().unwrap();
         let source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        let path = manager.repo_path(&source);
+        let path = manager.repo_path(&source).unwrap();
 
         assert!(path.ends_with("github/owner/repo"));
     }
@@ -524,25 +701,70 @@ mod tests {
     fn test_repo_path_with_subpath() {
         let manager = CacheManager::new().unwrap();
         let source = GitHubSource::parse("https://github.com/owner/repo/tree/main/subdir").unwrap();
-        let path = manager.repo_path(&source);
+        let path = manager.repo_path(&source).unwrap();
 
         // Subpath should not affect cache path (repo is cached, subpath is used at read time)
         assert!(path.ends_with("github/owner/repo"));
     }
 
     #[test]
-    fn test_cache_dir_function() {
-        let dir = cache_dir();
-        assert!(dir.is_ok());
-        let dir = dir.unwrap();
+    fn test_parse_cache_dir_override_none() {
+        assert_eq!(parse_cache_dir_override(None).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_cache_dir_override_empty_rejected() {
+        let err = parse_cache_dir_override(Some(OsStr::new(""))).unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_cache_dir_override_relative_rejected() {
+        let err = parse_cache_dir_override(Some(OsStr::new("custom-cache"))).unwrap_err();
+        assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn test_parse_cache_dir_override_absolute_accepted() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path();
+        let parsed = parse_cache_dir_override(Some(path.as_os_str())).unwrap();
+        assert_eq!(parsed, Some(path.to_path_buf()));
+    }
+
+    #[test]
+    fn test_default_cache_dir_function() {
+        let dir = default_cache_dir().unwrap();
         assert!(dir.to_string_lossy().contains("repoverlay"));
     }
 
     #[test]
-    fn test_cache_manager_cache_dir_accessor() {
+    fn test_cache_manager_cache_dir_accessor_uses_current_resolution() {
+        let expected = std::env::var_os("REPOVERLAY_CACHE_DIR").map_or_else(
+            || default_cache_dir().unwrap(),
+            |value| {
+                parse_cache_dir_override(Some(value.as_os_str()))
+                    .unwrap()
+                    .unwrap()
+            },
+        );
+
         let manager = CacheManager::new().unwrap();
-        let dir = manager.cache_dir();
-        assert!(dir.to_string_lossy().contains("repoverlay"));
+        assert_eq!(manager.cache_dir(), expected.as_path());
+    }
+
+    #[test]
+    fn test_configured_source_cache_path_rejects_invalid_name() {
+        let temp = TempDir::new().unwrap();
+        let err = configured_source_cache_path(temp.path(), "bad/name").unwrap_err();
+        assert!(err.to_string().contains("path separators"));
+    }
+
+    #[test]
+    fn test_configured_source_cache_path_joins_sources_namespace() {
+        let temp = TempDir::new().unwrap();
+        let path = configured_source_cache_path(temp.path(), "overlay").unwrap();
+        assert_eq!(path, temp.path().join("sources/overlay"));
     }
 
     #[test]
@@ -623,14 +845,36 @@ mod tests {
     }
 
     #[test]
+    fn test_list_cached_sources_sorted_and_skips_non_directories() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let sources_dir = temp.path().join("sources");
+        fs::create_dir_all(&sources_dir).unwrap();
+        fs::write(sources_dir.join("ignored.txt"), "content").unwrap();
+        fs::create_dir_all(sources_dir.join("zeta")).unwrap();
+        fs::create_dir_all(sources_dir.join("alpha")).unwrap();
+
+        let sources = manager.list_cached_sources().unwrap();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].name, "alpha");
+        assert_eq!(sources[0].path, sources_dir.join("alpha"));
+        assert_eq!(sources[1].name, "zeta");
+        assert_eq!(sources[1].path, sources_dir.join("zeta"));
+    }
+
+    #[test]
     fn test_clear_cache_empty() {
         let temp = TempDir::new().unwrap();
         let manager = CacheManager {
             cache_dir: temp.path().to_path_buf(),
         };
 
-        let count = manager.clear_cache().unwrap();
-        assert_eq!(count, 0);
+        let counts = manager.clear_cache().unwrap();
+        assert_eq!(counts.github, 0);
+        assert_eq!(counts.sources, 0);
     }
 
     #[test]
@@ -646,11 +890,246 @@ mod tests {
         fs::create_dir_all(&repo1).unwrap();
         fs::create_dir_all(&repo2).unwrap();
 
-        let count = manager.clear_cache().unwrap();
-        assert_eq!(count, 2);
+        let counts = manager.clear_cache().unwrap();
+        assert_eq!(counts.github, 2);
+        assert_eq!(counts.sources, 0);
 
         // Verify directory is removed
         assert!(!temp.path().join("github").exists());
+    }
+
+    #[test]
+    fn test_clear_cache_sources_only() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let keep = temp.path().join("keep.txt");
+        fs::write(&keep, "keep").unwrap();
+        let source_path = temp.path().join("sources/alpha");
+        fs::create_dir_all(&source_path).unwrap();
+
+        let counts = manager.clear_cache().unwrap();
+        assert_eq!(counts.github, 0);
+        assert_eq!(counts.sources, 1);
+        assert!(!temp.path().join("sources").exists());
+        assert!(keep.exists());
+    }
+
+    #[test]
+    fn test_clear_cache_with_both_namespaces() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        fs::create_dir_all(temp.path().join("github/owner1/repo1")).unwrap();
+        fs::create_dir_all(temp.path().join("github/owner2/repo2")).unwrap();
+        fs::create_dir_all(temp.path().join("sources/alpha")).unwrap();
+        fs::create_dir_all(temp.path().join("sources/beta")).unwrap();
+        let keep = temp.path().join("preserve.txt");
+        fs::write(&keep, "keep").unwrap();
+
+        let counts = manager.clear_cache().unwrap();
+        assert_eq!(counts.github, 2);
+        assert_eq!(counts.sources, 2);
+        assert!(!temp.path().join("github").exists());
+        assert!(!temp.path().join("sources").exists());
+        assert!(keep.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_clear_cache_removes_symlinked_namespaces_without_following_targets() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let github_target = temp.path().join("github-target");
+        let sources_target = temp.path().join("sources-target");
+        let github_repo = github_target.join("owner/repo");
+        let sources_clone = sources_target.join("alpha");
+        fs::create_dir_all(&github_repo).unwrap();
+        fs::create_dir_all(&sources_clone).unwrap();
+        fs::write(github_repo.join("sentinel.txt"), "github-sentinel").unwrap();
+        fs::write(sources_clone.join("sentinel.txt"), "sources-sentinel").unwrap();
+
+        let github_link = temp.path().join("github");
+        let sources_link = temp.path().join("sources");
+        unix_fs::symlink(&github_target, &github_link).unwrap();
+        unix_fs::symlink(&sources_target, &sources_link).unwrap();
+
+        let counts = manager.clear_cache().unwrap();
+        assert_eq!(counts.github, 1);
+        assert_eq!(counts.sources, 1);
+        assert!(github_target.exists());
+        assert!(sources_target.exists());
+        assert_eq!(
+            fs::read_to_string(github_repo.join("sentinel.txt")).unwrap(),
+            "github-sentinel"
+        );
+        assert_eq!(
+            fs::read_to_string(sources_clone.join("sentinel.txt")).unwrap(),
+            "sources-sentinel"
+        );
+        assert!(!github_link.exists());
+        assert!(!sources_link.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_clear_cache_rejects_symlinked_cache_root() {
+        let temp = TempDir::new().unwrap();
+        let external_root = temp.path().join("external-root");
+        let github_target = external_root.join("github");
+        let sources_target = external_root.join("sources");
+        let github_repo = github_target.join("owner/repo");
+        let sources_clone = sources_target.join("alpha");
+        fs::create_dir_all(&github_repo).unwrap();
+        fs::create_dir_all(&sources_clone).unwrap();
+        fs::write(github_repo.join("sentinel.txt"), "github-sentinel").unwrap();
+        fs::write(sources_clone.join("sentinel.txt"), "sources-sentinel").unwrap();
+
+        let cache_root = temp.path().join("cache-root");
+        unix_fs::symlink(&external_root, &cache_root).unwrap();
+
+        let manager = CacheManager {
+            cache_dir: cache_root.clone(),
+        };
+
+        let err = manager.clear_cache().unwrap_err();
+        assert!(err.to_string().contains("cache root is not a directory"));
+        assert_eq!(
+            fs::read_to_string(github_repo.join("sentinel.txt")).unwrap(),
+            "github-sentinel"
+        );
+        assert_eq!(
+            fs::read_to_string(sources_clone.join("sentinel.txt")).unwrap(),
+            "sources-sentinel"
+        );
+        assert!(
+            fs::symlink_metadata(&cache_root)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_rejects_symlinked_cache_root() {
+        let temp = TempDir::new().unwrap();
+        let external_root = temp.path().join("external-root");
+        fs::create_dir_all(external_root.join("github/owner/repo")).unwrap();
+        fs::write(
+            external_root.join("github/owner/repo/sentinel.txt"),
+            "repo-sentinel",
+        )
+        .unwrap();
+        fs::create_dir_all(external_root.join("sources/alpha")).unwrap();
+        fs::write(
+            external_root.join("sources/alpha/sentinel.txt"),
+            "source-sentinel",
+        )
+        .unwrap();
+
+        let cache_root = temp.path().join("cache-root");
+        unix_fs::symlink(&external_root, &cache_root).unwrap();
+
+        let manager = CacheManager {
+            cache_dir: cache_root.clone(),
+        };
+
+        let err = manager.remove_cached("owner", "repo").unwrap_err();
+        assert!(err.to_string().contains("cache root is not a directory"));
+        let err = manager.remove_cached_source("alpha").unwrap_err();
+        assert!(err.to_string().contains("cache root is not a directory"));
+        assert_eq!(
+            fs::read_to_string(external_root.join("github/owner/repo/sentinel.txt")).unwrap(),
+            "repo-sentinel"
+        );
+        assert_eq!(
+            fs::read_to_string(external_root.join("sources/alpha/sentinel.txt")).unwrap(),
+            "source-sentinel"
+        );
+        assert!(
+            fs::symlink_metadata(&cache_root)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_rejects_symlinked_github_namespace() {
+        let temp = TempDir::new().unwrap();
+        let external_github = temp.path().join("external-github");
+        fs::create_dir_all(external_github.join("owner/repo")).unwrap();
+        fs::write(
+            external_github.join("owner/repo/sentinel.txt"),
+            "github-sentinel",
+        )
+        .unwrap();
+
+        fs::create_dir_all(temp.path().join("sources")).unwrap();
+        let github_link = temp.path().join("github");
+        unix_fs::symlink(&external_github, &github_link).unwrap();
+
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let err = manager.remove_cached("owner", "repo").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cache github namespace is not a directory")
+        );
+        assert_eq!(
+            fs::read_to_string(external_github.join("owner/repo/sentinel.txt")).unwrap(),
+            "github-sentinel"
+        );
+        assert!(
+            fs::symlink_metadata(&github_link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_rejects_symlinked_owner_parent() {
+        let temp = TempDir::new().unwrap();
+        let external_owner = temp.path().join("external-owner");
+        fs::create_dir_all(external_owner.join("repo")).unwrap();
+        fs::write(external_owner.join("repo/sentinel.txt"), "owner-sentinel").unwrap();
+
+        fs::create_dir_all(temp.path().join("github")).unwrap();
+        let owner_link = temp.path().join("github/owner");
+        unix_fs::symlink(&external_owner, &owner_link).unwrap();
+
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let err = manager.remove_cached("owner", "repo").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cache github owner is not a directory")
+        );
+        assert_eq!(
+            fs::read_to_string(external_owner.join("repo/sentinel.txt")).unwrap(),
+            "owner-sentinel"
+        );
+        assert!(
+            fs::symlink_metadata(&owner_link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]
@@ -678,6 +1157,146 @@ mod tests {
         let removed = manager.remove_cached("owner", "repo").unwrap();
         assert!(removed);
         assert!(!repo_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_symlink_entry_removes_link_only() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let target = temp.path().join("external-owner");
+        let repo_target = target.join("repo");
+        fs::create_dir_all(&repo_target).unwrap();
+        fs::write(repo_target.join("sentinel.txt"), "repo-sentinel").unwrap();
+
+        let repo_link = temp.path().join("github/owner/repo");
+        fs::create_dir_all(temp.path().join("github/owner")).unwrap();
+        unix_fs::symlink(&repo_target, &repo_link).unwrap();
+
+        let removed = manager.remove_cached("owner", "repo").unwrap();
+        assert!(removed);
+        assert!(repo_target.exists());
+        assert_eq!(
+            fs::read_to_string(repo_target.join("sentinel.txt")).unwrap(),
+            "repo-sentinel"
+        );
+        assert!(fs::symlink_metadata(&repo_link).is_err());
+    }
+
+    #[test]
+    fn test_remove_cached_rejects_invalid_components() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let err = manager.remove_cached("bad/owner", "repo").unwrap_err();
+        assert!(err.to_string().contains("path separators"));
+
+        let err = manager.remove_cached("owner", "bad/repo").unwrap_err();
+        assert!(err.to_string().contains("path separators"));
+    }
+
+    #[test]
+    fn test_remove_cached_source_nonexistent() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let removed = manager.remove_cached_source("source").unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_remove_cached_source_existing() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let source_path = temp.path().join("sources/source");
+        fs::create_dir_all(&source_path).unwrap();
+
+        let removed = manager.remove_cached_source("source").unwrap();
+        assert!(removed);
+        assert!(!source_path.exists());
+        assert!(!temp.path().join("sources").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_source_rejects_invalid_name_before_fs_access() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let external_sources = temp.path().join("external-sources");
+        fs::create_dir(&external_sources).unwrap();
+        let sources_link = temp.path().join("sources");
+        unix_fs::symlink(&external_sources, &sources_link).unwrap();
+
+        let err = manager.remove_cached_source("bad/name").unwrap_err();
+        assert!(err.to_string().contains("path separators"));
+        assert!(external_sources.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_source_rejects_symlinked_sources_parent() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let external_sources = temp.path().join("external-sources");
+        let external_child = external_sources.join("child");
+        fs::create_dir_all(&external_child).unwrap();
+        fs::write(external_child.join("payload.txt"), "content").unwrap();
+
+        let sources_link = temp.path().join("sources");
+        unix_fs::symlink(&external_sources, &sources_link).unwrap();
+
+        let err = manager.remove_cached_source("child").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cache sources namespace is not a directory")
+        );
+        assert!(external_child.exists());
+        assert!(external_child.join("payload.txt").exists());
+        assert!(
+            fs::symlink_metadata(&sources_link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_cached_source_symlink_entry_removes_link_only() {
+        let temp = TempDir::new().unwrap();
+        let manager = CacheManager {
+            cache_dir: temp.path().to_path_buf(),
+        };
+
+        let target = temp.path().join("external-source");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("payload.txt"), "content").unwrap();
+
+        let source_link = temp.path().join("sources/source");
+        fs::create_dir_all(temp.path().join("sources")).unwrap();
+        unix_fs::symlink(&target, &source_link).unwrap();
+
+        let removed = manager.remove_cached_source("source").unwrap();
+        assert!(removed);
+        assert!(target.exists());
+        assert!(target.join("payload.txt").exists());
+        assert!(fs::symlink_metadata(&source_link).is_err());
     }
 
     #[test]
@@ -1121,7 +1740,7 @@ mod tests {
             cache_dir: temp.path().to_path_buf(),
         };
         let source = GitHubSource::parse("https://github.com/owner/repo").unwrap();
-        let repo_path = manager.repo_path(&source);
+        let repo_path = manager.repo_path(&source).unwrap();
 
         // Create directory to trigger the "cache hit" branch (update=false path)
         // but it's not a real git repo, so checkout_ref will fail

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -4,6 +4,7 @@ use std::io::{self, Write};
 
 use super::super::CacheCommand;
 use crate::CacheManager;
+use crate::cache::{CachedRepoInfo, CachedSourceInfo};
 
 pub(crate) fn handle_cache_command(command: CacheCommand) -> Result<()> {
     let cache = CacheManager::new()?;
@@ -11,57 +12,67 @@ pub(crate) fn handle_cache_command(command: CacheCommand) -> Result<()> {
     match command {
         CacheCommand::List => {
             let repos = cache.list_cached()?;
+            let sources = cache.list_cached_sources()?;
 
-            if repos.is_empty() {
-                println!("{} No repositories cached.", "Cache:".bold());
+            if repos.is_empty() && sources.is_empty() {
+                println!(
+                    "{} No cached GitHub repositories or configured source clones.",
+                    "Cache:".bold()
+                );
                 return Ok(());
             }
 
-            println!("{} {} cached repository(s):", "Cache:".bold(), repos.len());
+            println!("{}", "Cache:".bold());
             println!();
 
-            for repo in repos {
-                println!("  {}/{}", repo.owner.cyan(), repo.repo);
-                if let Some(meta) = repo.meta {
-                    println!("    Ref:     {}", meta.requested_ref);
-                    println!("    Commit:  {}", &meta.commit[..12.min(meta.commit.len())]);
-                    println!(
-                        "    Fetched: {}",
-                        meta.last_fetched.format("%Y-%m-%d %H:%M UTC")
-                    );
-                }
-                println!("    Path:    {}", repo.path.display());
-                println!();
-            }
+            print_cached_github_repositories(&repos);
+            println!();
+            print_cached_source_clones(&sources);
         }
 
-        CacheCommand::Remove { repo, all, yes } => {
+        CacheCommand::Remove {
+            repo,
+            source,
+            all,
+            yes,
+        } => {
             if all {
                 clear_cache(&cache, yes)?;
             } else if let Some(repo) = repo {
                 let parts: Vec<&str> = repo.split('/').collect();
                 if parts.len() != 2 {
-                    bail!("Invalid repository format. Use: owner/repo");
+                    bail!("Invalid GitHub repository format. Use: owner/repo");
                 }
 
                 let (owner, repo_name) = (parts[0], parts[1]);
 
                 if cache.remove_cached(owner, repo_name)? {
                     println!(
-                        "{} Removed {}/{} from cache.",
+                        "{} Removed GitHub repository {}/{} from cache.",
                         "✓".green().bold(),
                         owner,
                         repo_name
                     );
                 } else {
-                    println!("{owner}/{repo_name} is not cached.");
+                    println!("GitHub repository {owner}/{repo_name} is not cached.");
+                }
+            } else if let Some(source) = source {
+                if cache.remove_cached_source(&source)? {
+                    println!(
+                        "{} Removed configured source clone {} from cache.",
+                        "✓".green().bold(),
+                        source
+                    );
+                } else {
+                    println!("Configured source clone {source} is not cached.");
                 }
             } else {
                 bail!(
-                    "Specify a repository to remove or use --all.\n\n\
+                    "Specify a GitHub repository, --source <name>, or --all.\n\n\
                      Usage:\n  \
-                     repoverlay cache remove <owner/repo>  # Remove specific repo\n  \
-                     repoverlay cache remove --all          # Remove all cached repos"
+                     repoverlay cache remove <owner/repo>  # Remove a cached GitHub repository\n  \
+                     repoverlay cache remove --source <name>  # Remove a cached configured source clone\n  \
+                     repoverlay cache remove --all          # Remove all cached GitHub repositories and configured source clones"
                 );
             }
         }
@@ -77,23 +88,62 @@ pub(crate) fn handle_cache_command(command: CacheCommand) -> Result<()> {
 /// Clear the entire cache with optional confirmation prompt.
 fn clear_cache(cache: &CacheManager, skip_confirm: bool) -> Result<()> {
     if !skip_confirm {
-        print!("Remove all cached repositories? [y/N] ");
+        print!("Remove all cached GitHub repositories and configured source clones? [y/N] ");
         io::stdout().flush()?;
 
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
 
         if !input.trim().eq_ignore_ascii_case("y") {
-            println!("Cancelled.");
+            println!("Cancelled. No GitHub repositories or configured source clones were removed.");
             return Ok(());
         }
     }
 
-    let count = cache.clear_cache()?;
+    let counts = cache.clear_cache()?;
     println!(
-        "{} Removed {} cached repository(s).",
+        "{} Removed {} GitHub repository(s) and {} configured source clone(s).",
         "✓".green().bold(),
-        count
+        counts.github,
+        counts.sources
     );
     Ok(())
+}
+
+fn print_cached_github_repositories(repos: &[CachedRepoInfo]) {
+    println!("{}", "GitHub repositories".bold());
+
+    if repos.is_empty() {
+        println!("  (none cached)");
+        return;
+    }
+
+    for repo in repos {
+        println!("  {}/{}", repo.owner.cyan(), repo.repo);
+        if let Some(meta) = &repo.meta {
+            println!("    Ref:     {}", meta.requested_ref);
+            println!("    Commit:  {}", &meta.commit[..12.min(meta.commit.len())]);
+            println!(
+                "    Fetched: {}",
+                meta.last_fetched.format("%Y-%m-%d %H:%M UTC")
+            );
+        }
+        println!("    Path:    {}", repo.path.display());
+        println!();
+    }
+}
+
+fn print_cached_source_clones(sources: &[CachedSourceInfo]) {
+    println!("{}", "Configured source clones".bold());
+
+    if sources.is_empty() {
+        println!("  (none cached)");
+        return;
+    }
+
+    for source in sources {
+        println!("  {}", source.name.cyan());
+        println!("    Path:    {}", source.path.display());
+        println!();
+    }
 }

--- a/src/cli/commands/source.rs
+++ b/src/cli/commands/source.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use super::super::SourceCommand;
 use super::find_repo_root;
 use crate::config;
+use crate::path_safety::validate_path_component;
 
 /// Handle source subcommands.
 pub(crate) fn handle_source_command(command: SourceCommand) -> Result<()> {
@@ -49,6 +50,7 @@ pub(crate) fn handle_source_command(command: SourceCommand) -> Result<()> {
                     );
                 }
 
+                validate_path_component(&source_name)?;
                 if source_name.starts_with('@') {
                     bail!(
                         "Source names starting with '@' are reserved. '@library' is a built-in source."
@@ -108,6 +110,7 @@ pub(crate) fn handle_source_command(command: SourceCommand) -> Result<()> {
                     );
                 }
 
+                validate_path_component(&source_name)?;
                 if source_name.starts_with('@') {
                     bail!(
                         "Source names starting with '@' are reserved. '@library' is a built-in source."

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -621,20 +621,24 @@ pub(crate) enum ProfileCommand {
 
 #[derive(Subcommand)]
 pub(crate) enum CacheCommand {
-    /// List cached repositories
+    /// List cached GitHub repositories and configured-source clones
     List,
 
-    /// Remove cached repositories
+    /// Remove cached GitHub repositories and configured-source clones
     Remove {
-        /// Repository to remove (format: owner/repo)
-        #[arg(conflicts_with = "all")]
+        /// Cached GitHub repository to remove (format: owner/repo)
+        #[arg(conflicts_with_all = ["source", "all"])]
         repo: Option<String>,
 
-        /// Remove all cached repositories
-        #[arg(short, long)]
+        /// Cached source clone to remove by source name
+        #[arg(long, conflicts_with_all = ["repo", "all"])]
+        source: Option<String>,
+
+        /// Remove all cached GitHub repositories and configured-source clones
+        #[arg(short, long, conflicts_with_all = ["repo", "source"])]
         all: bool,
 
-        /// Skip confirmation prompt (used with --all)
+        /// Skip confirmation prompt when removing all cache entries
         #[arg(short = 'y', long)]
         yes: bool,
     },
@@ -3271,6 +3275,7 @@ directories =
             // Invalid format (no slash)
             let result = handle_cache_command(CacheCommand::Remove {
                 repo: Some("invalid".to_string()),
+                source: None,
                 all: false,
                 yes: false,
             });
@@ -3279,7 +3284,7 @@ directories =
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Invalid repository format")
+                    .contains("Invalid GitHub repository format")
             );
         }
 
@@ -3287,6 +3292,7 @@ directories =
         fn cache_remove_fails_on_too_many_slashes() {
             let result = handle_cache_command(CacheCommand::Remove {
                 repo: Some("a/b/c".to_string()),
+                source: None,
                 all: false,
                 yes: false,
             });
@@ -3295,7 +3301,7 @@ directories =
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Invalid repository format")
+                    .contains("Invalid GitHub repository format")
             );
         }
 
@@ -3303,6 +3309,7 @@ directories =
         fn cache_remove_fails_when_no_repo_or_all() {
             let result = handle_cache_command(CacheCommand::Remove {
                 repo: None,
+                source: None,
                 all: false,
                 yes: false,
             });
@@ -3311,7 +3318,7 @@ directories =
                 result
                     .unwrap_err()
                     .to_string()
-                    .contains("Specify a repository")
+                    .contains("Specify a GitHub repository")
             );
         }
     }
@@ -5278,8 +5285,31 @@ directories =
 
             match cli.command {
                 Some(Commands::Cache { command }) => match command {
-                    CacheCommand::Remove { repo, all, .. } => {
+                    CacheCommand::Remove {
+                        repo, source, all, ..
+                    } => {
                         assert_eq!(repo, Some("owner/repo".to_string()));
+                        assert!(source.is_none());
+                        assert!(!all);
+                    }
+                    _ => panic!("Expected Cache Remove subcommand"),
+                },
+                _ => panic!("Expected Cache command"),
+            }
+        }
+
+        #[test]
+        fn cache_remove_parses_source() {
+            let cli = Cli::try_parse_from(["repoverlay", "cache", "remove", "--source", "overlay"])
+                .unwrap();
+
+            match cli.command {
+                Some(Commands::Cache { command }) => match command {
+                    CacheCommand::Remove {
+                        repo, source, all, ..
+                    } => {
+                        assert!(repo.is_none());
+                        assert_eq!(source, Some("overlay".to_string()));
                         assert!(!all);
                     }
                     _ => panic!("Expected Cache Remove subcommand"),
@@ -5295,8 +5325,14 @@ directories =
 
             match cli.command {
                 Some(Commands::Cache { command }) => match command {
-                    CacheCommand::Remove { repo, all, yes } => {
+                    CacheCommand::Remove {
+                        repo,
+                        source,
+                        all,
+                        yes,
+                    } => {
                         assert!(repo.is_none());
+                        assert!(source.is_none());
                         assert!(all);
                         assert!(yes);
                     }
@@ -5304,6 +5340,39 @@ directories =
                 },
                 _ => panic!("Expected Cache command"),
             }
+        }
+
+        #[test]
+        fn cache_remove_repo_and_source_conflict() {
+            let result = Cli::try_parse_from([
+                "repoverlay",
+                "cache",
+                "remove",
+                "owner/repo",
+                "--source",
+                "overlay",
+            ]);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn cache_remove_repo_and_all_conflict() {
+            let result =
+                Cli::try_parse_from(["repoverlay", "cache", "remove", "owner/repo", "--all"]);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn cache_remove_source_and_all_conflict() {
+            let result = Cli::try_parse_from([
+                "repoverlay",
+                "cache",
+                "remove",
+                "--source",
+                "overlay",
+                "--all",
+            ]);
+            assert!(result.is_err());
         }
 
         #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use crate::cache::{cache_dir, configured_source_cache_path};
 use crate::fs_util::atomic_write;
 
 /// Global repoverlay configuration.
@@ -43,9 +44,7 @@ impl RepoverlayConfig {
             )
         })?;
 
-        let cache_dir = directories::ProjectDirs::from("", "", "repoverlay")
-            .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
-        let local_path = cache_dir.cache_dir().join("sources").join(&source.name);
+        let local_path = configured_source_cache_path(&cache_dir()?, &source.name)?;
         Ok(OverlayRepoConfig {
             url: source.url()?.to_string(),
             local_path: Some(local_path),
@@ -80,9 +79,7 @@ impl RepoverlayConfig {
                 )
             })?;
 
-        let cache_dir = directories::ProjectDirs::from("", "", "repoverlay")
-            .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
-        let local_path = cache_dir.cache_dir().join("sources").join(&source.name);
+        let local_path = configured_source_cache_path(&cache_dir()?, &source.name)?;
 
         Ok(OverlayRepoConfig {
             url: source.url()?.to_string(),
@@ -1195,6 +1192,24 @@ sources =
         assert!(result.is_err());
     }
 
+    #[test]
+    fn test_get_default_overlay_repo_config_rejects_invalid_source_name() {
+        let config = RepoverlayConfig {
+            sources: vec![Source {
+                name: "bad/source".to_string(),
+                url: Some("https://github.com/test/overlays".to_string()),
+                path: None,
+            }],
+            library_path: None,
+            profiles: std::collections::BTreeMap::new(),
+            marketplaces: Vec::new(),
+        };
+
+        let result = config.get_default_overlay_repo_config();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path separators"));
+    }
+
     // ==================== get_overlay_repo_config_by_name tests ====================
 
     #[test]
@@ -1258,6 +1273,24 @@ sources =
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("nonexistent"));
         assert!(err_msg.contains("primary"));
+    }
+
+    #[test]
+    fn test_get_overlay_repo_config_by_name_rejects_invalid_source_name() {
+        let config = RepoverlayConfig {
+            sources: vec![Source {
+                name: "bad/source".to_string(),
+                url: Some("https://github.com/org/repo".to_string()),
+                path: None,
+            }],
+            library_path: None,
+            profiles: std::collections::BTreeMap::new(),
+            marketplaces: Vec::new(),
+        };
+
+        let result = config.get_overlay_repo_config_by_name(Some("bad/source"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path separators"));
     }
 
     // ==================== SourceUrlInput tests ====================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1922,7 +1922,7 @@ mod tests {
 
             // Get the path where CacheManager would store this repo
             // This includes the "github" subdirectory: {cache_dir}/github/{owner}/{repo}
-            let expected_repo_path = cache.repo_path(&source);
+            let expected_repo_path = cache.repo_path(&source).unwrap();
 
             // Create overlay structure at the correct cache location
             let overlay_path = expected_repo_path.join("target-org/target-repo/test-overlay");
@@ -1967,7 +1967,7 @@ mod tests {
             let source =
                 GitHubSource::parse("https://github.com/test-owner-xyz/test-repo-xyz").unwrap();
 
-            let cache_manager_path = cache.repo_path(&source);
+            let cache_manager_path = cache.repo_path(&source).unwrap();
 
             // Verify the cache manager path includes "github" subdirectory
             assert!(

--- a/src/path_safety.rs
+++ b/src/path_safety.rs
@@ -100,7 +100,6 @@ pub(crate) fn validate_repo_relative_path(path: &Path) -> Result<()> {
 ///
 /// For example, `my-overlay` and `user_config` are accepted, while
 /// `../etc`, `name/with/slash`, and empty strings are rejected.
-#[allow(dead_code)] // Infrastructure for future call-site migrations (#323)
 pub(crate) fn validate_path_component(component: &str) -> Result<()> {
     // Reject empty components
     if component.is_empty() {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -10,7 +10,7 @@ use crate::cache::CacheManager;
 use crate::config;
 use crate::fuzzy::OverlayMatcher;
 use crate::github;
-use crate::github::GitHubSource;
+use crate::github::{GitHubSource, GitRef};
 use crate::library;
 use crate::overlay_name::OverlayName;
 use crate::overlay_repo::AvailableOverlay;
@@ -664,8 +664,12 @@ pub(crate) fn list_overlays_from_cached_repo(
     debug!("listing overlays from cached GitHub repo: {owner}/{repo}");
 
     let cache = CacheManager::new()?;
-    let cache_dir = cache.cache_dir();
-    let repo_path = cache_dir.join("github").join(owner).join(repo);
+    let repo_path = cache.repo_path(&GitHubSource {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        git_ref: GitRef::Default,
+        subpath: None,
+    })?;
 
     if !repo_path.exists() {
         bail!("Repository not cached: {owner}/{repo}");
@@ -1356,6 +1360,13 @@ mod tests {
         }
 
         #[test]
+        fn list_overlays_from_cached_repo_rejects_invalid_owner() {
+            let result = list_overlays_from_cached_repo("bad/owner", "repo");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("path separators"));
+        }
+
+        #[test]
         fn list_overlays_from_cached_repo_finds_overlays_at_correct_path() {
             use crate::cache::CacheManager;
             use crate::github::GitHubSource;
@@ -1371,7 +1382,7 @@ mod tests {
 
             // Get the path where CacheManager would store this repo
             // This includes the "github" subdirectory: {cache_dir}/github/{owner}/{repo}
-            let expected_repo_path = cache.repo_path(&source);
+            let expected_repo_path = cache.repo_path(&source).unwrap();
 
             // Create overlay structure at the correct cache location
             let overlay_path = expected_repo_path.join("target-org/target-repo/test-overlay");
@@ -1416,7 +1427,7 @@ mod tests {
             let source =
                 GitHubSource::parse("https://github.com/test-owner-xyz/test-repo-xyz").unwrap();
 
-            let cache_manager_path = cache.repo_path(&source);
+            let cache_manager_path = cache.repo_path(&source).unwrap();
 
             // Verify the cache manager path includes "github" subdirectory
             assert!(

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::OverlayName;
+use crate::cache::{cache_dir, configured_source_cache_path};
 use crate::config::{OverlayRepoConfig, Source};
 use crate::overlay_repo::{AvailableOverlay, OverlayRepoManager};
 use crate::state::ResolvedVia;
@@ -67,20 +68,21 @@ pub(crate) struct SourceManager {
     sources: Vec<ManagedSource>,
 }
 
-/// Cache directory for sources.
-fn sources_cache_dir() -> Result<PathBuf> {
-    let base = directories::ProjectDirs::from("", "", "repoverlay")
-        .ok_or_else(|| anyhow::anyhow!("Could not determine cache directory"))?;
-    Ok(base.cache_dir().join("sources"))
-}
-
 impl SourceManager {
     /// Create a new source manager from a list of sources.
     ///
     /// Each git source is configured to clone to a subdirectory within the cache.
     /// Local sources resolve their path relative to `repo_root`.
     pub(crate) fn new(sources: Vec<Source>, repo_root: Option<&Path>) -> Result<Self> {
-        let cache_dir = sources_cache_dir()?;
+        let cache_root = cache_dir()?;
+        Self::new_with_cache_root(sources, repo_root, &cache_root)
+    }
+
+    fn new_with_cache_root(
+        sources: Vec<Source>,
+        repo_root: Option<&Path>,
+        cache_root: &Path,
+    ) -> Result<Self> {
         let managed_sources = sources
             .into_iter()
             .map(|source| {
@@ -113,7 +115,7 @@ impl SourceManager {
                         path: canonical_path,
                     }
                 } else {
-                    let local_path = cache_dir.join(&source.name);
+                    let local_path = configured_source_cache_path(cache_root, &source.name)?;
                     let config = OverlayRepoConfig {
                         url: source.url()?.to_string(),
                         local_path: Some(local_path),
@@ -146,6 +148,15 @@ impl SourceManager {
             .iter()
             .find(|s| s.source.name == name)
             .map(|s| &s.source)
+    }
+
+    /// Get the base filesystem path used by a source backend.
+    #[must_use]
+    pub(crate) fn get_source_base_path(&self, name: &str) -> Option<&Path> {
+        self.sources
+            .iter()
+            .find(|s| s.source.name == name)
+            .map(|s| s.backend.repo_path())
     }
 
     /// Ensure all git sources are cloned.
@@ -384,14 +395,6 @@ impl SourceManager {
         let mut result: Vec<_> = names.into_iter().collect();
         result.sort();
         Ok(result)
-    }
-
-    /// Get the base path for a named source.
-    pub(crate) fn get_source_base_path(&self, source_name: &str) -> Option<&Path> {
-        self.sources
-            .iter()
-            .find(|ms| ms.source.name == source_name)
-            .map(|ms| ms.backend.repo_path())
     }
 
     /// Get the current commit for a named source.
@@ -1414,42 +1417,29 @@ mod tests {
     #[test]
     fn test_source_names() {
         let temp = TempDir::new().unwrap();
-        let cache_dir = temp.path();
 
         let sources = vec![
             Source {
                 name: "personal".to_string(),
-                url: Some("file://dummy".to_string()),
+                url: Some("https://github.com/user/overlays".to_string()),
                 path: None,
             },
             Source {
                 name: "team".to_string(),
-                url: Some("file://dummy".to_string()),
+                url: Some("https://github.com/team/overlays".to_string()),
                 path: None,
             },
         ];
 
-        let manager = SourceManager {
-            sources: sources
-                .into_iter()
-                .map(|source| {
-                    let local_path = cache_dir.join(&source.name);
-                    let config = OverlayRepoConfig {
-                        url: source.url().unwrap().to_string(),
-                        local_path: Some(local_path),
-                    };
-                    ManagedSource {
-                        source,
-                        backend: ManagedSourceBackend::Git(
-                            OverlayRepoManager::new(config).unwrap(),
-                        ),
-                    }
-                })
-                .collect(),
-        };
+        let manager =
+            SourceManager::new_with_cache_root(sources, Some(temp.path()), temp.path()).unwrap();
 
         let names = manager.source_names();
         assert_eq!(names, vec!["personal", "team"]);
+        assert_eq!(
+            manager.get_source_base_path("team").unwrap(),
+            temp.path().join("sources/team")
+        );
     }
 
     #[test]
@@ -1693,21 +1683,24 @@ mod tests {
         assert!(overlays.is_empty());
     }
 
-    /// Test that `sources_cache_dir` returns error when `ProjectDirs` is unavailable.
-    /// This catches mutants that would replace the error with `Ok(Default::default())`.
+    /// Test that `SourceManager::new_with_cache_root` uses a single `sources` segment.
     #[test]
-    fn sources_cache_dir_fails_without_project_dirs() {
-        // The function should return an error, not Ok(PathBuf::new())
-        let result = sources_cache_dir();
-        assert!(
-            result.is_ok(),
-            "sources_cache_dir should work in test environment with valid home dir"
-        );
-        // Verify it returns a valid path, not an empty default
-        let path = result.unwrap();
-        assert!(
-            !path.as_os_str().is_empty(),
-            "sources_cache_dir should not return empty path"
+    fn configured_source_cache_path_uses_single_sources_segment() {
+        let base = TempDir::new().unwrap();
+        let manager = SourceManager::new_with_cache_root(
+            vec![Source {
+                name: "team".to_string(),
+                url: Some("https://github.com/test/team".to_string()),
+                path: None,
+            }],
+            Some(base.path()),
+            base.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            manager.get_source_base_path("team").unwrap(),
+            base.path().join("sources/team")
         );
     }
 
@@ -2412,6 +2405,20 @@ mod tests {
 
         // pull_all should not error on local sources
         assert!(manager.pull_all().is_ok());
+    }
+
+    #[test]
+    fn test_git_source_name_rejects_path_separators() {
+        let sources = vec![Source {
+            name: "bad/source".to_string(),
+            url: Some("https://github.com/owner/repo".to_string()),
+            path: None,
+        }];
+
+        let Err(err) = SourceManager::new(sources, None) else {
+            panic!("expected invalid source name to be rejected");
+        };
+        assert!(err.to_string().contains("path separators"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,6 +8,7 @@ use predicates::prelude::*;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -39,6 +40,52 @@ impl SourceTestContext {
         let mut cmd = cargo_bin_cmd!("repoverlay");
         cmd.env("XDG_CONFIG_HOME", self.config_dir.path());
         cmd
+    }
+}
+
+/// Context for testing cache commands with isolated cache storage.
+///
+/// Uses an explicit cache-dir override so Windows path resolution stays isolated.
+struct CacheTestContext {
+    root_dir: tempfile::TempDir,
+    cache_dir: PathBuf,
+}
+
+impl CacheTestContext {
+    fn new() -> Self {
+        let root_dir = tempfile::TempDir::new().expect("Failed to create temp cache root");
+        let cache_dir = root_dir.path().join("repoverlay-cache");
+        Self {
+            root_dir,
+            cache_dir,
+        }
+    }
+
+    fn cmd(&self) -> assert_cmd::Command {
+        let mut cmd = cargo_bin_cmd!("repoverlay");
+        cmd.env("HOME", self.root_dir.path())
+            .env("XDG_CACHE_HOME", self.root_dir.path())
+            .env("APPDATA", self.root_dir.path())
+            .env("LOCALAPPDATA", self.root_dir.path())
+            .env("USERPROFILE", self.root_dir.path())
+            .env("REPOVERLAY_CACHE_DIR", &self.cache_dir);
+        cmd
+    }
+
+    fn cache_root(&self) -> PathBuf {
+        let output = self
+            .cmd()
+            .args(["cache", "path"])
+            .output()
+            .expect("Failed to read cache path");
+        assert!(output.status.success());
+        let cache_root = PathBuf::from(
+            String::from_utf8(output.stdout)
+                .expect("Cache path must be UTF-8")
+                .trim(),
+        );
+        assert_eq!(cache_root, self.cache_dir);
+        cache_root
     }
 }
 
@@ -274,11 +321,128 @@ fn root_help_browse_listed_as_recommended() {
 
 #[test]
 fn cache_help_displays() {
-    cargo_bin_cmd!("repoverlay")
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
         .args(["cache", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("cache"));
+        .stdout(predicate::str::contains("GitHub repositories"))
+        .stdout(predicate::str::contains("configured-source clones"));
+}
+
+#[test]
+fn cache_remove_help_mentions_source_selector() {
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--source"))
+        .stdout(predicate::str::contains("--all"))
+        .stdout(predicate::str::contains("source clone"))
+        .stdout(predicate::str::contains("GitHub repositories"));
+}
+
+#[test]
+fn cache_list_shows_both_namespaces() {
+    let ctx = CacheTestContext::new();
+    let cache_root = ctx.cache_root();
+    fs::create_dir_all(cache_root.join("github/owner/repo")).unwrap();
+    fs::create_dir_all(cache_root.join("sources/overlay")).unwrap();
+
+    ctx.cmd()
+        .args(["cache", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("GitHub repositories"))
+        .stdout(predicate::str::contains("owner/repo"))
+        .stdout(predicate::str::contains("Configured source clones"))
+        .stdout(predicate::str::contains("overlay"));
+}
+
+#[test]
+fn cache_remove_source_removes_unconfigured_clone() {
+    let ctx = CacheTestContext::new();
+    let source_path = ctx.cache_root().join("sources/overlay");
+    fs::create_dir_all(&source_path).unwrap();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--source", "overlay"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Removed configured source clone overlay from cache.",
+        ));
+
+    assert!(!source_path.exists());
+}
+
+#[test]
+fn cache_remove_missing_source_reports_not_cached() {
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--source", "missing"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Configured source clone missing is not cached.",
+        ));
+}
+
+#[test]
+fn cache_remove_invalid_source_name_propagates_validation_error() {
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--source", "bad/name"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("path separators"));
+}
+
+#[test]
+fn cache_remove_all_reports_both_counts() {
+    let ctx = CacheTestContext::new();
+    let cache_root = ctx.cache_root();
+    let sentinel = ctx.root_dir.path().join("outside-cache-sentinel.txt");
+    fs::write(&sentinel, "keep").unwrap();
+    fs::create_dir_all(cache_root.join("github/owner/repo")).unwrap();
+    fs::create_dir_all(cache_root.join("sources/overlay")).unwrap();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--all", "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Removed 1 GitHub repository(s) and 1 configured source clone(s).",
+        ));
+
+    assert!(!cache_root.join("github").exists());
+    assert!(!cache_root.join("sources").exists());
+    assert_eq!(fs::read_to_string(&sentinel).unwrap(), "keep");
+}
+
+#[test]
+fn cache_remove_all_cancellation_works() {
+    let ctx = CacheTestContext::new();
+    let cache_root = ctx.cache_root();
+    fs::create_dir_all(cache_root.join("github/owner/repo")).unwrap();
+    fs::create_dir_all(cache_root.join("sources/overlay")).unwrap();
+
+    ctx.cmd()
+        .args(["cache", "remove", "--all"])
+        .write_stdin("n\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Cancelled. No GitHub repositories or configured source clones were removed.",
+        ));
+
+    assert!(cache_root.join("github/owner/repo").exists());
+    assert!(cache_root.join("sources/overlay").exists());
 }
 
 #[test]
@@ -2784,6 +2948,7 @@ profiles =
 
 #[test]
 fn deprecated_cli_surfaces_are_rejected() {
+    let ctx = CacheTestContext::new();
     cargo_bin_cmd!("repoverlay")
         .args(["create-local", "--help"])
         .assert()
@@ -2792,7 +2957,7 @@ fn deprecated_cli_surfaces_are_rejected() {
         .args(["list", "--help"])
         .assert()
         .failure();
-    cargo_bin_cmd!("repoverlay")
+    ctx.cmd()
         .args(["cache", "clear", "--help"])
         .assert()
         .failure();
@@ -2829,11 +2994,6 @@ fn replacement_cli_surfaces_are_available() {
         .args(["edit", "remove", "--help"])
         .assert()
         .success();
-    cargo_bin_cmd!("repoverlay")
-        .args(["cache", "remove", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("--all"));
 }
 
 #[test]
@@ -2972,19 +3132,38 @@ fn remove_when_no_overlay() {
 
 #[test]
 fn cache_list_empty() {
-    cargo_bin_cmd!("repoverlay")
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
         .args(["cache", "list"])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains(
+            "No cached GitHub repositories or configured source clones.",
+        ));
 }
 
 #[test]
 fn cache_path_shows_location() {
-    cargo_bin_cmd!("repoverlay")
+    let ctx = CacheTestContext::new();
+    let output = ctx.cmd().args(["cache", "path"]).output().unwrap();
+    assert!(output.status.success());
+
+    let cache_root = PathBuf::from(String::from_utf8(output.stdout).unwrap().trim());
+    assert_eq!(cache_root, ctx.cache_dir);
+    assert_eq!(cache_root.parent(), Some(ctx.root_dir.path()));
+}
+
+#[test]
+fn cache_path_rejects_relative_override() {
+    let ctx = CacheTestContext::new();
+
+    ctx.cmd()
+        .env("REPOVERLAY_CACHE_DIR", "custom-cache")
         .args(["cache", "path"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("repoverlay"));
+        .failure()
+        .stderr(predicate::str::contains("absolute path"));
 }
 
 // ============================================================================
@@ -3899,14 +4078,6 @@ fn apply_conflicting_file_warns_or_fails() {
 // Cache Command Tests
 // ============================================================================
 
-#[test]
-fn cache_remove_help() {
-    cargo_bin_cmd!("repoverlay")
-        .args(["cache", "remove", "--help"])
-        .assert()
-        .success();
-}
-
 // ============================================================================
 // Security Tests
 // ============================================================================
@@ -4166,24 +4337,6 @@ fn apply_with_special_characters_in_filename() {
         .success();
 
     assert!(ctx.file_exists("file with spaces.txt"));
-}
-
-#[test]
-fn cache_list_runs_without_error() {
-    // Just test that cache list command runs without crashing
-    cargo_bin_cmd!("repoverlay")
-        .args(["cache", "list"])
-        .assert()
-        .success();
-}
-
-#[test]
-fn cache_path_shows_directory() {
-    cargo_bin_cmd!("repoverlay")
-        .args(["cache", "path"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("repoverlay"));
 }
 
 // ============================================================================
@@ -4581,6 +4734,45 @@ fn source_add_local_extracts_name_from_dir() {
         .assert()
         .success()
         .stdout(predicate::str::contains("team-overlays"));
+}
+
+#[test]
+fn source_add_rejects_invalid_local_source_name() {
+    let ctx = TestContext::new();
+    let config_dir = tempfile::TempDir::new().unwrap();
+
+    let overlays_dir = ctx.repo_path().join("my-overlays");
+    fs::create_dir_all(&overlays_dir).unwrap();
+
+    cargo_bin_cmd!("repoverlay")
+        .args(["source", "add", "./my-overlays", "--name", "bad/name"])
+        .current_dir(ctx.repo_path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("path separators"));
+}
+
+#[test]
+fn source_add_rejects_invalid_git_source_name() {
+    let ctx = SourceTestContext::new();
+
+    ctx.cmd()
+        .args(["source", "add", "owner/repo", "--name", "bad/name"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("path separators"));
+}
+
+#[test]
+fn source_add_preserves_reserved_source_names() {
+    let ctx = SourceTestContext::new();
+
+    ctx.cmd()
+        .args(["source", "add", "owner/repo", "--name", "@library"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("reserved"));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- include configured-source clones in cache listings
- add targeted `cache remove --source` support
- make `cache remove --all` clear GitHub and configured-source caches
- validate cache paths and symlink parents before deletion
- update cache documentation, generated CLI reference, and changelog

## Testing

- `cargo test --all-features`
- `just check`
- `just docs`
- `changie batch --dry-run auto`

Closes #396
